### PR TITLE
Typos in 2014-12-16.pod

### DIFF
--- a/2014/articles/2014-12-16.pod
+++ b/2014/articles/2014-12-16.pod
@@ -11,7 +11,7 @@ consistent and clean.
 =head2 Perl::Tidy
 
 Many of us are familiar with L<Perl::Tidy> (the Perl module for reformatting
-your source code in a cosistent manner according to a set of rules,) so we'll
+your source code in a consistent manner according to a set of rules,) so we'll
 start with it as an example.  Since the elves work as a team, it's easiest for
 them to add their common C<< .perltidyrc >> to their Git repository.  Next they
 create an rc file for the C<< tidyall >> command line utility.  They add this to
@@ -26,7 +26,6 @@ the top level of their repository and call it C<< .tidyallrc >>:
 Each section of a C<< .tidyallrc >> file begins by specifying the
 tidier/formatter which is being configured.  In this case it's the
 L<Code::TidyAll::Plugin::PerlTidy> plugin which plugs L<Perl::Tidy> into
-
 C<< tidyall >>.  The C<< select >> args accept L<File::Zglob> patterns (i.e.
 shell glob pattern).  This allows the elves to configure which files the plugin
 should be applied to.  Similarly, they can also add C<< ignore >> patterns to
@@ -131,9 +130,9 @@ latest commits from master and run the following command:
 This will set up a hook which runs before any git commit in the local repo is
 finalized.  Note that the hook will not tidy your files.  It will merely warn
 you about untidy code and prevent the commit.  (You can get the same behaviour
-at the command line by suppling the C<< --check-only >> arg).  At this point you
+at the command line by supplying the C<< --check-only >> arg).  At this point you
 can check what the problems are and then run C<< tidyall -g >> as appropriate.
-Then be sure to commit your tidying before you commit.  If you don't,
+Then be sure to perform your tidying before you commit.  If you don't,
 C<< tidyall >> will be fooled into thinking that your commits are clean, even
 if you haven't staged the tidied bits.
 


### PR DESCRIPTION
I've fixed some obvious typos here. Also have changed this sentence: "Then be sure to commit your tidying before you commit." replacing the first "commit" with "perform". I'm less sure that "perform" is the ideal replacement but am confident that it is better than having 2 "commit"s like that which is confusing.
