### PR TITLE
fix CLDR TL;DR issues from PR #26

### DIFF
--- a/2014/submission/cldr-tldr.pod
+++ b/2014/submission/cldr-tldr.pod
@@ -61,9 +61,9 @@ Here’s an example of formatting numbers:
 Now let’s see the results in European Spanish, Mexican Spanish, and Bengali:
 
 =for :list
-* C<es-ES: 123 456,7>
-* C<es-MX: 123,456.7>
-* C<bn-IN: ১,২৩,৪৫৬.৭>
+* es-ES: 123 456,7
+* es-MX: 123,456.7
+* bn-IN: ১,২৩,৪৫৬.৭
 
 This demonstrates that both the language and the country can significantly
 change the results of basic number formatting. Now let’s see this applied to
@@ -77,10 +77,10 @@ Here are the results in American English and Canadian English for both US
 Dollars and Canadian Dollars.
 
 =for :list
-* C<en-US / USD: $9.99>
-* C<en-CA / USD: US$9.99>
-* C<en-CA / CAD: $9.99>
-* C<en-US / CAD: CA$9.99>
+* en-US / USD: $9.99
+* en-CA / USD: US$9.99
+* en-CA / CAD: $9.99
+* en-US / CAD: CA$9.99
 
 This demonstrates that localized formatting is important even when your only
 supported language is English. When it comes to currency formatting, the
@@ -111,9 +111,9 @@ to format the entire list. Let’s take a look at the results in Portuguese,
 French, and Urdu.
 
 =for :list
-* C<pt: “foo”, “bar” e “baz”>
-* C<fr: «foo», «bar» et «baz»>
-* C<ur: ”foo“، ”bar“، اور ”baz“>
+* pt: “foo”, “bar” e “baz”
+* fr: «foo», «bar» et «baz»
+* ur: ”foo“، ”bar“، اور ”baz“
 
 Note that for support of all locales, you currently have to use the Locale::CLDR
 v0.25.x release on CPAN instead of v0.26.x because the latter is in the process


### PR DESCRIPTION
changes in response to PR #26 (which was already merged):
- remove pod `=encoding`
- add shebang for perl syntax highlighting
- replace example using U+201E DOUBLE LOW-9 QUOTATION MARK to avoid Chrome bug

plus:
- explicitly `use` modules in code examples
- minor text changes
