### PR TITLE
add valid gravatar email address

### DIFF
--- a/2014/articles/2014-12-23.pod
+++ b/2014/articles/2014-12-23.pod
@@ -1,6 +1,6 @@
 Title: CLDR TL;DR
 Topic: Unicode CLDR 
-Author: Nick Patch <@nickpatch>
+Author: Nick Patch <patch@cpan.org>
 
 2014 has been an exciting year for CLDR development on the CPAN. But first, what
 is the CLDR? The L<Unicode Common Locale Data Repository|http://cldr.unicode.org/>
@@ -71,6 +71,7 @@ prices in different currencies.
 
     #!perl
     my $curf = $cldr->currency_formatter(currency_code => $currency);
+
     say "$locale / $currency: ", $curf->format(9.99);
 
 Here are the results in American English and Canadian English for both US
@@ -102,9 +103,9 @@ Here is a simple solution to formatting a list of strings for the user:
     use Locale::CLDR;
 
     my $cldr = Locale::CLDR->new($locale);
-    my @stuff = qw( foo bar baz );
+    my @gifts = qw( foo bar baz );
 
-    say "$locale: ", $cldr->list(map { $cldr->quote($_) } @stuff);
+    say "$locale: ", $cldr->list(map { $cldr->quote($_) } @gifts);
 
 The C<quote> method is used to quote each element and the C<list> method is used
 to format the entire list. Let’s take a look at the results in Portuguese,


### PR DESCRIPTION
Hi Mark,

I noticed that the avatars are using Gravatar based on the author's email, so I added a valid address (plus a couple minor tweaks). This is a very low priority, so don't worry if you don't have time to push this today.

Thanks for all your work on the Perl Advent calendar! I've enjoyed reading it throughout the month.

Best,
Nick
