### PR TITLE
Y2015 text hogan improvements

### DIFF
--- a/2015/submissions/text-hogan.pod
+++ b/2015/submissions/text-hogan.pod
@@ -43,7 +43,7 @@ A smile crept across Santa's face. "Ho ho ho, I know of a solution to both your
 problems", he said, his grin widening. Have you heard of Mustache? The elves
 shook their head, but one of them brought up the website on his icePhone 6.
 
-<Mustache|http://mustache.github.io/> provides logic-less templates and has
+L<Mustache|http://mustache.github.io/> provides logic-less templates and has
 parsers for multiple languages including JavaScript and Perl!
 
 By being logic-less you're forced to put your logic into your Perl modules

--- a/2015/submissions/text-hogan.pod
+++ b/2015/submissions/text-hogan.pod
@@ -122,8 +122,8 @@ based ones, and written tests for all their code that was previously locked
 away in template files. Hooray! But then one day, shortly before Christmas,
 another bug report came in:
 
-I don't think we can use these new templates during the Christmas rush. Our
-metrics show that the site has gotten much slower since we switched.
+"I don't think we can use these new templates during the Christmas rush. Our
+metrics show that the site has gotten much slower since we switched."
 
 Luckily one of the elvish development team was ready for this. Not wanting to
 fall into the trap of premature optimization he hadn't yet used one of hogan.js

--- a/2015/submissions/text-hogan.pod
+++ b/2015/submissions/text-hogan.pod
@@ -72,6 +72,7 @@ In Perl:
 
 In JavaScript:
 
+    #!vim javascript
     var text = "Hello, {{name}}!";
 
     var template = Hogan.compile(text);


### PR DESCRIPTION
Three small changes here:

- Added the JS syntax highlighting hint as discussed in https://github.com/perladvent/Perl-Advent/pull/37
- Fixed a link (bad POD syntax)
- Added quotes on the final bug for readability