### PR TITLE
Correct misspelling of "misspellings"

### DIFF
--- a/2016/articles/2016-12-03.pod
+++ b/2016/articles/2016-12-03.pod
@@ -5,7 +5,7 @@ Author: perlancar <perlancar@cpan.org>
 =pod
 
 Santa had a problem. Due to increased use of machine transcription, his list of children's names contained
-far more mispellings than previously, and really had to be
+far more misspellings than previously, and really had to be
 checked twice. Santa ordered one of the elves to write a Perl script for
 this task, but there was a catch - with more than a billion names on the list,
 the script needed to be fast.


### PR DESCRIPTION
Simply correct one ironic typo.