### PR TITLE
syntax highlighting, remove redundant paragraph

### DIFF
--- a/2016/articles/2016-12-06.pod
+++ b/2016/articles/2016-12-06.pod
@@ -26,10 +26,6 @@ niceness assessment process over the year:
 
 =back
 
-Santa's elves are not very enthusiastic about implementing this in Perl. How can
-they design their processes in order to minimize the mess? How can they unit
-test this to make sure things don't randomly fail in the future?
-
 Santa's elves are not very enthusiastic about implementing this in Perl, with
 all the code required to track if the parents have filled in the forms or not
 and building the logic to trigger the right part of their existing code base at
@@ -52,6 +48,7 @@ above.
 In L<Schedule::LongSteps>, the process we are modeling is simply modeled as a
 class that extends Schedule::LongSteps:
 
+  #!perl
   package My::Process::NicenessFeedback;
 
   use Moose; # There are a lot of them in Santa's land.
@@ -78,6 +75,7 @@ store data for you in various ways, typically in a SQL database.
 Before we flesh out the My::Process::NicenessFeedback module, let's look
 at how we might instantiate it with the Schedule::LongSteps module:
 
+  #!perl
   my $sl = Schedule::LongSteps->new();
 
   $sl->instantiate_process(
@@ -96,6 +94,7 @@ This state will be accessible inside our object using the C<state> method, and
 while the state has to be a pure Perl data structure we can use builder methods
 to populate attributes with more complex objects:
 
+  #!perl
   package My::Process::NicenessFeedback;
   ...
   has 'child' => ( is => 'ro', lazy_build => 1 );
@@ -113,6 +112,7 @@ The process now has a child!
 We can now define what it should do first. For this, we first implement the
 (mandatory) method 'build_first_step' method:
 
+  #!perl
   sub build_first_step{
       my ($self) = @_;
       # At the beginning of February next year
@@ -134,6 +134,7 @@ We'd better implement the code for the steps in our class next...
 Steps in the process are implemented as methods. The convention is to name them
 with the prefix 'do_', to avoid any possible conflict with future methods.
 
+  #!perl
   sub do_send_form_to_parents{
       my ($self) = @_;
 
@@ -213,6 +214,7 @@ future. How do we make sure today that this process will work?'
 
 Well, this is where unit testing comes into play. Here's how to write a test:
 
+  #!perl
   use Test::MockDateTime;
   my $longsteps = Schedule::LongSteps->new();
 


### PR DESCRIPTION
- added #!perl so code would be syntax highlighted
- two paragraphs were largely identical, I assume one was a re-write of the other