### PR TITLE
Fix typos in Syntax::Keyword::Try

### DIFF
--- a/2016/articles/2016-12-12.pod
+++ b/2016/articles/2016-12-12.pod
@@ -258,14 +258,14 @@ Finally A proper comparison would be amiss without a feature comparison chart:
     <th>Syntax::Keyword::Try</th>
   </tr>
   <tr class="alt">
-    <td>Requires no dependancies</td>
+    <td>Requires no dependencies</td>
     <td class="supports">&#10004;</td>
     <td class="notsupports">&#10007;</td>
     <td class="notsupports">&#10007;</td>
     <td class="notsupports">&#10007;</td>
   </tr>
   <tr>
-    <td>Perl Perl solution</td>
+    <td>Pure Perl solution</td>
     <td class="supports">&#10004;</td>
     <td class="supports">&#10004;</td>
     <td class="notsupports">&#10007;</td>


### PR DESCRIPTION
2 minor typos in the comparison table