### PR TITLE
Fix code quoting

### DIFF
--- a/2018/articles/2018-12-11.pod
+++ b/2018/articles/2018-12-11.pod
@@ -155,7 +155,7 @@ C<ro> and C<lazy> syntax.  Instead of having to write the long C<has> statements
 you can just use the much shorter syntax."
 
 Yule's face lit up.  The C<ro 'filename'> wasn't any more code that writing
-C<my $filename>.  The C<lazy 'count' => sub ($self,@)> wasn't really any
+C<my $filename>.  The C<< lazy 'count' => sub ($self,@) >> wasn't really any
 longer than writing a simple subroutine declaration.  This was Moo without
 all the overhead!
 


### PR DESCRIPTION
"=>" contains ">" which is taken as the closing angle bracket for the
surrounding C<>. Use C<<>> to fix.