### PR TITLE
Stop using entities in code samples

### DIFF
--- a/2020/articles/2020-12-05.pod
+++ b/2020/articles/2020-12-05.pod
@@ -93,7 +93,7 @@ respectively.
 
   #!perl
   # load File::stat so that 'stat()' will now return a "File::stat"
-  # object that methods like '$st-&gt;mode' can be called on
+  # object that methods like '$st->mode' can be called on
   use File::stat;
   
   # build a big hash that is keyed by the name of the file and in
@@ -108,9 +108,9 @@ respectively.
 
     # store the mode, modification time and size of the file
     # in a hash so we can access it later
-    $stats{ $file }{size}  = $stat-&gt;size;
-    $stats{ $file }{mtime} = $stat-&gt;mtime;
-    $stats{ $file }{mode}  = $stat-&gt;mtime;
+    $stats{ $file }{size}  = $stat->size;
+    $stats{ $file }{mtime} = $stat->mtime;
+    $stats{ $file }{mode}  = $stat->mtime;
   }
 
   print "Storing the the hash takes ".
@@ -131,9 +131,9 @@ small hashes?
   #!perl
   # define constants that refer to the index the elements
   # are in the array
-  use constant FILE_SIZE  =&gt; 0;
-  use constant FILE_MTIME =&gt; 1;
-  use constant FILE_MODE  =&gt; 2;
+  use constant FILE_SIZE  => 0;
+  use constant FILE_MTIME => 1;
+  use constant FILE_MODE  => 2;
 
   my %stats2;
   foreach my $file (@files)
@@ -143,9 +143,9 @@ small hashes?
 
     # store the mode, modification time and size of the file
     # in an array so we can access it later
-    $stats2{ $file }[FILE_SIZE]  = $stat-&gt;size;
-    $stats2{ $file }[FILE_MTIME] = $stat-&gt;mtime;
-    $stats2{ $file }[FILE_MODE]  = $stat-&gt;mtime;
+    $stats2{ $file }[FILE_SIZE]  = $stat->size;
+    $stats2{ $file }[FILE_MTIME] = $stat->mtime;
+    $stats2{ $file }[FILE_MODE]  = $stat->mtime;
   }
 
   print "Storing the the hash takes ".
@@ -167,9 +167,9 @@ I use a list of hashes?
 
     # store the mode, modification time and size of the file
     # in an array so we can access it later
-    $stats3[FILE_SIZE]{ $file }  = $stat-&gt;size;
-    $stats3[FILE_MTIME]{ $file } = $stat-&gt;mtime;
-    $stats3[FILE_MODE]{ $file }  = $stat-&gt;mtime;
+    $stats3[FILE_SIZE]{ $file }  = $stat->size;
+    $stats3[FILE_MTIME]{ $file } = $stat->mtime;
+    $stats3[FILE_MODE]{ $file }  = $stat->mtime;
   }
 
   print "Storing the the array takes ".


### PR DESCRIPTION
They are presented literally which is wrong, "-&gt;" should have been
"->".