### PR TITLE
Fix module name

### DIFF
--- a/2020/articles/2020-12-10.pod
+++ b/2020/articles/2020-12-10.pod
@@ -1,5 +1,5 @@
-Title: Regex::Common
-Topic: Regex::Common
+Title: Regexp::Common
+Topic: Regexp::Common
 Author: Mark Fowler <mark@twoshortplanks.com>
 
 =for :html
@@ -88,21 +88,21 @@ this I get to thinking...wouldn't it be I<nice> if someone had written
 this already.  It's a fairly common occurrence - it's not like we're
 the first people ever to want to match a number.
 
-And then we look in Regex::Common.  Lo and behold!  There's one there to
+And then we look in Regexp::Common.  Lo and behold!  There's one there to
 do it!  Remind me again why I'm writing my own code?
 
-Using B<Regex::Common> exports a hash C<%RE> into our namespace.  This
+Using B<Regexp::Common> exports a hash C<%RE> into our namespace.  This
 hash contains many compiled regexes which we an use in our regular
 expressions.  For example:
 
     #!perl
     $scalar =~ /$RE{num}{real}/;
 
-B<Regex::Common> also provides a subroutine method to get at the
+B<Regexp::Common> also provides a subroutine method to get at the
 regexes, if you prefer to use it like that:
 
     #!perl
-    use Regex::Common 'RE_ALL';
+    use Regexp::Common 'RE_ALL';
     my $regex = RE_num_real();
     if ($scalar =~ $regex)
       { print "It matched!" }
@@ -115,12 +115,12 @@ on them and treat them just like they're objects.
     if ($num_regex-&gt;match($scalar))
       { print "It matched!" }
 
-One thing you can say about B<Regex::Common>, it provides a lot of
+One thing you can say about B<Regexp::Common>, it provides a lot of
 syntactic sugar.
 
-=head2 What Regex::Common can match
+=head2 What Regexp::Common can match
 
-I'm not going to provide examples of everything that B<Regex::Common>
+I'm not going to provide examples of everything that B<Regexp::Common>
 can match - that would take forever and a day.  I'm just going to touch
 on some of the things that I've found most useful.
 
@@ -129,7 +129,7 @@ the most useful is the profanity matching.  This is impossible to do
 properly without really annoying the residents of Middlesex and
 Scunthorpe by blocking out the inappropriate words in their place names,
 and you can only provide basic checking that's 'good enough'.
-B<Regex::Common> provides a collection that's 'good enough' from the
+B<Regexp::Common> provides a collection that's 'good enough' from the
 outset, and means I no longer have to worry about constructing such
 things.
 


### PR DESCRIPTION
As reported on [PerlMonks](https://www.perlmonks.org/?node_id=11125595), it appears that the module name for article 2020-12-10 is incorrect. This PR fixes the name only.