### PR TITLE
Add 2015 through 2020 entries to archives.yaml

### DIFF
--- a/archives.yaml
+++ b/archives.yaml
@@ -906,10 +906,64 @@
   21:
   - { "module": "dbicdump" }
   22:
-    - { "topic": "Custom Relationships with DBIx::Class" }
+  - { "topic": "Custom Relationships with DBIx::Class" }
   23:
   - { "module": "Params::ValidationCompiler" }
   24:
   - { "module": "WWW::YouTube::Download" }
   25:
   - { topic: "Perl Advent 2017", href: "http://perladvent.org/2017" }
+
+2018:
+  01:
+  - { "module": "Calendar::List" }
+  02:
+  - { "module": "WebPerl" }
+  03:
+  - { "module": "Cpanel::JSON::XS::Type" }
+  04:
+  - { "module": "B::perlstring" }
+  05:
+  - { "module": "Data::Rmap" }
+  06:
+  - { "module": "Array::Sticky::INC" }
+  07:
+  - { "module": "Text::CSV::Pivot" }
+  08:
+  - { "module": "DBD::MariaDB" }
+  09:
+  - { "module": "App::Sigfix" }
+  10:
+  - { "module": "Babble" }
+  11:
+  - { "module": "Mu" }
+  12:
+  - { "module": "SVG" }
+  - { "module": "SVG::ChristmasTree" }
+  13:
+  - { "module": "Sub::Params" }
+  14:
+  - { "topic": "Future-based interfaces" }
+  15:
+  - { "module": "App::ccdiff" }
+  16:
+  - { "module": "Hash::Flatten" }
+  17:
+  - { "module": "OAuth::CmdLine::Spotify" }
+  18:
+  - { "module": "Test::Excel" }
+  19:
+  - { "module": "Mojo::Promise" }
+  20:
+  - { "topic": "iSH" }
+  21:
+  - { "module": "Devel::hdb" }
+  22:
+  - { "module": "Method::ParamValidator" }
+  23:
+  - { "module": "Context::Singleton" }
+  24:
+  - { "module": "App::HTTPThis" }
+  - { "module": "App::HTTPSThis" }
+  25:
+  - { topic: "Perl Advent 2018", href: "http://perladvent.org/2018" }

--- a/archives.yaml
+++ b/archives.yaml
@@ -1019,3 +1019,56 @@
   - { "module": "Imager" }
   25:
   - { topic: "Perl Advent 2019", href: "http://perladvent.org/2019" }
+
+2020:
+  01:
+  - { "module": "Code::TidyAll" }
+  02:
+  - { "module": "Import::Into" }
+  03:
+  - { "module": "Try::Tiny" }
+  04:
+  - { "module": "Stepford" }
+  05:
+  - { "module": "Devel::Size" }
+  06:
+  - { "module": "Ref::Util" }
+  07:
+  - { "module": "Const::Fast" }
+  08:
+  - { "module": "Mojo::Promise" }
+  09:
+  - { "module": "Params::ValidationCompiler" }
+  10:
+  - { "module": "Regexp::Common" }
+  11:
+  - { "module": "CPAN::Mini" }
+  12:
+  - { "module": "Wallflower" }
+  13:
+  - { "module": "SVG" }
+  - { "module": "SVG::ChristmasTree" }
+  14:
+  - { "module": "Tie::File" }
+  15:
+  - { "module": "Devel::MAT" }
+  16:
+  - { "module": "Scope::Upper" }
+  17:
+  - { "module": "Device::Chip::Adapter" }
+  18:
+  - { "module": "OAuth::CmdLine::Spotify" }
+  19:
+  - { "module": "List::Gather" }
+  20:
+  - { "module": "Devel::Hide" }
+  21:
+  - { "module": "Graph::Easy" }
+  22:
+  - { "module": "Safe::Isa" }
+  23:
+  - { "module": "Proc::Daemon" }
+  24:
+  - { "module": "Term::Choose" }
+  25:
+  - { topic: "Perl Advent 2020", href: "http://perladvent.org/2020" }

--- a/archives.yaml
+++ b/archives.yaml
@@ -858,3 +858,58 @@
   - { "module": "Test2::Bundle::Extended" }
   25:
   - { topic: "Perl Advent 2016", href: "http://perladvent.org/2016" }
+
+2017:
+  01:
+  - { "topic": "Printing Unicode with Perl" }
+  02:
+  - { "module": "Emoji::NationalFlag" }
+  03:
+  - { "topic": "Enforcing coding standards via Perl::Critic" }
+  04:
+  - { "topic": "Modern Heredocs" }
+  05:
+  - { "topic": "The Babycart Operator" }
+  06:
+  - { "module": "Import::Into" }
+  07:
+  - { "module": "Term::Choose" }
+  08:
+  - { "module": "Const::Fast" }
+  09:
+  - { "topic": "Recursive Regular Expressions with Named Groups" }
+  10:
+  - { "module": "Eval::Closure" }
+  11:
+  - { "module": "Path::Tiny" }
+  12:
+  - { "module": "Devel::MAT" }
+  13:
+  - { "module": "Unicode::UCD" }
+  14:
+  - { "module": "Perl::PrereqScanner" }
+  - { "module": "Perl::PrereqScanner::Lite" }
+  - { "module": "Perl::PrereqScanner::NotSoLite" }
+  15:
+  - { "module": "ojo" }
+  16:
+  - { "module": "MooseX::AttributeShortcuts" }
+  17:
+  - { "module": "MooseX::StrictConstructor" }
+  18:
+  - { "module": "MooseX::ClassAttribute" }
+  19:
+  - { "module": "MooseX::LazyRequire" }
+  - { "module": "MooseX::UndefTolerant::Attribute" }
+  20:
+  - { "module": "Reindeer" }
+  21:
+  - { "module": "dbicdump" }
+  22:
+    - { "topic": "Custom Relationships with DBIx::Class" }
+  23:
+  - { "module": "Params::ValidationCompiler" }
+  24:
+  - { "module": "WWW::YouTube::Download" }
+  25:
+  - { topic: "Perl Advent 2017", href: "http://perladvent.org/2017" }

--- a/archives.yaml
+++ b/archives.yaml
@@ -746,3 +746,59 @@
   - { "module": "AnyEvent" }
   25:
   - { topic: "Perl Advent 2014", href: "http://perladvent.org/2014" }
+
+2015:
+  01:
+  - { "module": "GeoIP2" }
+  02:
+  - { "module": "App::cpm" }
+  03:
+  - { "module": "FFI::Platypus" }
+  04:
+  - { "module": "Devel::Hide" }
+  05:
+  - { "module": "Lingua::EN::Inflexion" }
+  06:
+  - { "module": "Convert::CookingTimes" }
+  07:
+  - { "module": "Text::Hogan" }
+  08:
+  - { "module": "Reply" }
+  09:
+  - { "module": "Web::Query" }
+  10:
+  - { "module": "Module::CPANFile" }
+  11:
+  - { "module": "Smart::Comments" }
+  12:
+  - { "module": "Config::Station" }
+  13:
+  - { "module": "JSON::Path" }
+  14:
+  - { "module": "Acme::MetaSyntactic" }
+  15:
+  - { "module": "File::Serialize" }
+  16:
+  - { "module": "Stepford" }
+  17:
+  - { "module": "Process::Status" }
+  18:
+  - { "module": "Sereal" }
+  19:
+  - { "module": "Sort::ByExample" }
+  20:
+  - { "module": "Redis" }
+  - { "module": "Redis::Fast" }
+  - { "module": "Cache::Redis" }
+  - { "module": "Redis::LeaderBoard" }
+  - { "module": "Redis::Namespace" }
+  21:
+  - { "module": "feature" }
+  22:
+  - { "module": "AnsibleModule" }
+  23:
+  - { "module": "Mojo::UserAgent" }
+  24:
+  - { "module": "Device::Chip::Adapter" }
+  25:
+  - { topic: "Perl Advent 2015", href: "http://perladvent.org/2015" }

--- a/archives.yaml
+++ b/archives.yaml
@@ -802,3 +802,59 @@
   - { "module": "Device::Chip::Adapter" }
   25:
   - { topic: "Perl Advent 2015", href: "http://perladvent.org/2015" }
+
+2016:
+  01:
+  - { "module": "Meta::Grapher::Moose" }
+  02:
+  - { "module": "Ref::Util" }
+  03:
+  - { "module": "Bencher" }
+  04:
+  - { "module": "Log::Any" }
+  05:
+  - { "module": "List::Gather" }
+  06:
+  - { "module": "Schedule::LongSteps" }
+  07:
+  - { "module": "Git::Hooks" }
+  08:
+  - { "module": "Geo::Coder::OpenCage" }
+  09:
+  - { "module": "Params::Validate::Dependencies" }
+  10:
+  - { "module": "Text::CSV_XS" }
+  11:
+  - { "module": "Magpie" }
+  12:
+  - { "module": "Syntax::Keyword::Try" }
+  13:
+  - { "module": "Memoize" }
+  14:
+  - { "module": "PPI" }
+  15:
+  - { "module": "List::Util" }
+  16:
+  - { "module": "Geo::Parser::Text" }
+  17:
+  - { "module": "App::Spec" }
+  18:
+  - { "module": "Text::Fuzzy" }
+  19:
+  - { "module": "Linux::Clone" }
+  - { "module": "Linux::Unshare" }
+  - { "module": "Linux::Setns" }
+  20:
+  - { "module": "PDF::Reuse" }
+  21:
+  - { "module": "Dancer::SearchApp" }
+  22:
+  - { "module": "Algorithm::Kmeans" }
+  23:
+  - { "module": "HTTP::Caching" }
+  24:
+  - { "module": "Test2::Suite" }
+  - { "module": "Test2::Bundle::More" }
+  - { "module": "Test2::Bundle::Extended" }
+  25:
+  - { topic: "Perl Advent 2016", href: "http://perladvent.org/2016" }

--- a/archives.yaml
+++ b/archives.yaml
@@ -967,3 +967,55 @@
   - { "module": "App::HTTPSThis" }
   25:
   - { topic: "Perl Advent 2018", href: "http://perladvent.org/2018" }
+
+2019:
+  01:
+  - { "module": "Data::Password::zxcvbn" }
+  02:
+  - { "module": "WebService::HIBP" }
+  03:
+  - { "module": "Authen::OATH" }
+  04:
+  - { "topic": "FFI::Platypus and Go" }
+  05:
+  - { "topic": "Phillips Hue Home Bridge" }
+  06:
+  - { "module": "DarkSky::API" }
+  07:
+  - { "module": "Mo" }
+  08:
+  - { "module": "PerlIO::zip" }
+  09:
+  - { "module": "Net::EmptyPort" }
+  10:
+  - { "module": "Mojo::AsyncAwait" }
+  11:
+  - { "module": "Mojo::Transaction::Websocket" }
+  12:
+  - { "module": "GUIDeFATE" }
+  13:
+  - { "module": "HTTP::Message::PSGI" }
+  14:
+  - { "module": "GD" }
+  15:
+  - { "module": "AWS::Lambda::Quick" }
+  16:
+  - { "module": "Paws" }
+  17:
+  - { "module": "AWS::Lambda::PSGI" }
+  18:
+  - { "module": "Module::CoreList" }
+  19:
+  - { "module": "Memoize::Expire" }
+  20:
+  - { "topic": "iTerm and Perl" }
+  21:
+  - { "module": "Test2::V0" }
+  22:
+  - { "module": "Test2::Compare::Base" }
+  23:
+  - { "module": "App::yath" }
+  24:
+  - { "module": "Imager" }
+  25:
+  - { topic: "Perl Advent 2019", href: "http://perladvent.org/2019" }


### PR DESCRIPTION
I noticed the Perl Advent Calendar Archives only went through 2014. I updated archives.yaml with data from 2015 
through 2020 (each as a separate commit in the interim). Please feel free to verify the information (as I did catch a typo I made in the 2017 data when I added the 2018 data).

Respectfully,
Albert C. (atcroft on PerlMonks)