### PR TITLE
Clarify what an article topic is in article generator

### DIFF
--- a/script/new_article
+++ b/script/new_article
@@ -12,7 +12,7 @@ script/new_article - start a new Advent calendar article
 
 	% perl script/new_article
 	Article title > Another article
-	Article topic > Some stuff about something
+	Article topic > Module::Covered::In::Article
 	Author (Your Name) > brian d foy <bdfoy@cpan.org>
 	Saved the starter article in 2022/incoming/another-article.pod
 
@@ -48,7 +48,7 @@ sub cook_template {
 
 sub get_metadata {
 	my $title  = prompt( 'Article title' ) // 'Some title';
-	my $topic  = prompt( 'Article topic' ) // 'Some topic';
+	my $topic  = prompt( 'Article topic (Module::Covered::In::Article)' ) // 'Some topic';
 	my $author = prompt( 'Author (Your Name <your_email@example.com>)' ) // '';
 	( $title, $topic, $author );
 	}
@@ -76,13 +76,11 @@ Topic: %%TOPIC%%
 
 =encoding utf8
 
-=head1 %%TITLE%%
-
 =head2 Making links
 
-Your article here goes here. Make links with
-L<anchor text|http://example.com>. For module links, merely specify the
-module, like L<Pod::Simple>.
+Your article here goes here. The title will automatically be added by the site
+builder. Make links with L<anchor text|http://example.com>. For module links,
+merely specify the module, like L<Pod::Simple>.
 
 =head2 Inline code
 


### PR DESCRIPTION
In the vast majority of cases, the article covers mainly a single
module. This clarifies that. Also we don't add the title in the article,
as that is handled by the site builder.
