### PR TITLE
Restrict automated deploy action to official repo

### DIFF
--- a/2022/incoming/relocatable-perl.pod
+++ b/2022/incoming/relocatable-perl.pod
@@ -16,7 +16,7 @@ This is because I<system> perls are often out-of-date,
 so people don't have many chances to use the latest perl.
 
 It is true that you, an experienced Perl hacker, could build perl v5.36 by yourself.
-But people who are not very familiar with perl rarely build perl from source.
+But people who are not very familiar with Perl rarely build perl from source.
 
 Some programming languages,
 including L<nodejs|https://nodejs.org/en/download/> and


### PR DESCRIPTION
Per issue #250, this modification of the YAML appears to prevent the deploy action from running (and failing of course) on a schedule for repos other than the official one here.