### PR TITLE
Fix broken image (2008)

### DIFF
--- a/2008/12/index.html
+++ b/2008/12/index.html
@@ -22,7 +22,7 @@ ISMS  Thu Dec 25 09:07:31 2008 GMT . Thu Dec 25 04:07:31 2008 ET
 ITCH  Fri Dec 26 02:36:56 2008 GMT . Thu Dec 25 21:36:56 2008 ET
 ITEM  Fri Dec 26 02:45:33 2008 GMT . Thu Dec 25 21:45:33 2008 ET
 <center>&hellip;</center></span></pre>
-<p>While I could use <a href="http://www.thinkgeek.com/homeoffice/lights/a7c5/">The ThinkGeek Epoch Clock</a> to track this, it won't arrive by 6am today&hellip; And while it supports Roman numerals<sup><a href="#footnote_roman">1</a></sup>, which I don't need, it cannot display the time_t in the octal, hex, or ascii that I want; only hh:mm:ss is convertible.</p>
+<p>While I could use <a href="https://web.archive.org/web/20110916173113/http://www.thinkgeek.com/homeoffice/lights/a7c5/">The ThinkGeek Epoch Clock</a> to track this, it won't arrive by 6am today&hellip; And while it supports Roman numerals<sup><a href="#footnote_roman">1</a></sup>, which I don't need, it cannot display the time_t in the octal, hex, or ascii that I want; only hh:mm:ss is convertible.</p>
 <p>We can churn out a quick prototype with a couple of CORE features: <tt>un-</tt><tt><span class="k">pack</span></tt>, <tt><span class="w">Term::Cap</span></tt>, and <tt><span class="w">Time::HiRes</span></tt>.</p>
 <pre><span class="c"> 0.     1229079896
  1.    11120442530
@@ -31,7 +31,7 @@ ITEM  Fri Dec 26 02:45:33 2008 GMT . Thu Dec 25 21:45:33 2008 ET
  4. Fri Dec 12 06:04:56 2008
  5. Fri Dec 12 11:04:56 2008</span></pre>
 <p>But that's pretty dull in comparison to ThinkGeeks' lovely black monolith.</p>
-<p><a href="http://www.thinkgeek.com/homeoffice/lights/a7c5"><image src="http://www.thinkgeek.com/images/products/additional/large/a7c5_thinkgeek_clock_front.jpg"></a></p>
+<p><a href="https://web.archive.org/web/20110916173113/http://www.thinkgeek.com/homeoffice/lights/a7c5"><image src="https://web.archive.org/web/20110916173113/http://www.thinkgeek.com/images/products/additional/large/a7c5_thinkgeek_clock_front.jpg"></a></p>
 <p><tt><a href="http://search.cpan.org/perldoc?Tk">Tk</a></tt> to the rescue! Or not. I would like to try a <tt>Tk</tt> gui on Perl, but playing with Perl and PerlAdvent on my laptop has been a challenge this week, since a kernel security patch disconfigured my wifi, so I was not optimistic. I eventually bit the bullet and upgraded to <a href="http://www.ubuntu.com/">Ubuntu Intrepid Ibex</a>, forgetting that this would break my <a href="../../2007/17/">PerlAdvent tools</a> and <a href="../../2006/5/">Ack</a>, since they were built against <tt>/bin/perl</tt> (5.8.x). Ubuntu Intrepid Ibex sensibly moved up to the year old Perl <a href="../../2007/19/">5.10</a>, and now nothing works except core modules.</p>
 <p>Eventually, a quick <tt><span class="w">cpan</span> <span class="w">Tk</span></tt> lets me load this portable GUI library, and its tests begin popping-up a plethora of windows, a pleasant sign my luck is changing. Even better, the module comes with a <tt><span class="w">timer</span></tt> demo, which I was able to quickly wed to the CLI clock script&hellip;</p>
 <p><img src="Screenshot-Clock-tk.png" style="float:right"></p>

--- a/2008/12/mod12.pod
+++ b/2008/12/mod12.pod
@@ -31,7 +31,7 @@ ITEM  Fri Dec 26 02:45:33 2008 GMT . Thu Dec 25 21:45:33 2008 ET
 =end pre
 
 While I could use
-A<http://www.thinkgeek.com/homeoffice/lights/a7c5/|The ThinkGeek Epoch Clock> 
+A<https://web.archive.org/web/20110916173113/http://www.thinkgeek.com/homeoffice/lights/a7c5/|The ThinkGeek Epoch Clock> 
 to track this, it won't arrive by 6am today&hellip; And while it supports Roman
 numeralsN<roman>, which I don't need, it cannot display the time_t in the
 octal, hex, or ascii that I want; only hh:mm:ss is convertible.
@@ -52,7 +52,7 @@ We can churn out a quick prototype with a couple of CORE features:
 
 But that's pretty dull in comparison to ThinkGeeks' lovely black monolith.
 
-<a href="http://www.thinkgeek.com/homeoffice/lights/a7c5"><image src="http://www.thinkgeek.com/images/products/additional/large/a7c5_thinkgeek_clock_front.jpg"></a> 
+<a href="https://web.archive.org/web/20110916173113/http://www.thinkgeek.com/homeoffice/lights/a7c5"><image src="https://web.archive.org/web/20110916173113/http://www.thinkgeek.com/images/products/additional/large/a7c5_thinkgeek_clock_front.jpg"></a> 
 
 M<Tk> to the rescue! Or not. I would like to try a M<Tk> gui on Perl, but
 playing with Perl and PerlAdvent on my laptop has been a challenge this week,


### PR DESCRIPTION
2008-12 had deep links to the late, lamented ThinkGeek, breaking an image as well as link(s).

(Purpose was giving example of the `time_t` alarm clock being emulated in Perl, now gone.)

This PR fixes both the affected `IMG` and also the `A HREF`  links to (obsolete) product page to use IA Wayback Machine. 

(I _have_ checked my other pages for more broken images - none found - but **not** for 404 links. 
at least not  _Yet_.)