### PR TITLE
#207 - update references to how people can talk about the calendar

### DIFF
--- a/2008/FAQ-submit.html
+++ b/2008/FAQ-submit.html
@@ -1,7 +1,7 @@
 <html><head><title>Community Submissions</title></head>
 <body>
 <h1>Community Submissions</h1>
-Read on below for details before <a href="../contact.html">submitting</a> a write-up, or <a href="http://mail.pm.org/mailman/listinfo/perladvent">join the mail list</a>.
+Read on below for details before <a href="../contact.html">submitting</a> a write-up, or <s><a href="http://mail.pm.org/mailman/listinfo/perladvent">join the mail list</a></s> open an issue in the <a href="https://github.com/perladvent/Perl-Advent/issues/new">perl-advent/Perl-Advent GitHub repo</a>.
 
 <dl>
 <dt>What's the purpose of the calendar?
@@ -77,7 +77,7 @@ for future consideration.</p>
 <p>Hopefully all of the details have made things clearer, not scared you off,
 and you're ready to contribute and have some fun.</p><p>Best of luck.</p>
 
-<a name="1">1</a>. Underappreciated is not wholly exclusive of being listed on 
+<a name="1">1</a>. Underappreciated is not wholly exclusive of being listed on
 the <a href="http://qa.perl.org/phalanx/100/">Phalanx 100</a>, but it's much
 harder to make the case for something that's downloaded so often as being
 underappreciated.

--- a/2011/articles/2011-12-25.pod
+++ b/2011/articles/2011-12-25.pod
@@ -17,10 +17,11 @@ contribute an article for next year, you've got just about 365 days to do it!
 Lucky for you, 2012 is a leap year, and you'll get an extra day for planning.
 
 If you want to help with the site or other things in the meantime, you can
-L<join our mailing list|http://mail.pm.org/mailman/listinfo/perladvent> where
+<s>L<join our mailing list|http://mail.pm.org/mailman/listinfo/perladvent></s> L<visit
+the perl-advent/Perl-Advent GitHub repo|https://github.com/perladvent/Perl-Advent> where
 we'll be talking about work that needs to get done on things like the FAQ, the
 site generator, and all that sort of thing.  You can find the L<site's contents
-on GitHub|https://github.com/rjbs/Perl-Advent>, which I<should> contain the
+on GitHub|https://github.com/perladvent/Perl-Advent>, which I<should> contain the
 2011 articles by the time you see this.  It's not exactly how it should be, but
 it's there.
 
@@ -30,6 +31,6 @@ this job – have a merry Christmas and an excellent new year!
 =head1 See Also
 
 =for :list
-* L<https://github.com/rjbs/Perl-Advent>
-* L<http://mail.pm.org/mailman/listinfo/perladvent>
-* L<the soon-to-be-rewritten FAQ|http://www.perladvent.org/FAQ.html>
+* L<the perl-advent/Perl-Advent GitHub repo|https://github.com/perladvent/Perl-Advent/>
+* L<the someday-to-be-rewritten FAQ|http://www.perladvent.org/FAQ.html>
+* L<the mailing list|http://mail.pm.org/mailman/listinfo/perladvent> (historical archive)

--- a/2012/articles/2012-12-25.pod
+++ b/2012/articles/2012-12-25.pod
@@ -19,15 +19,16 @@ more submissions than we could publish, so we might already have fewer than 24
 slots open for 2013.  Wow!
 
 If you want to help with the site or other things in the meantime, you can
-L<join our mailing list|http://mail.pm.org/mailman/listinfo/perladvent> where
+<s>L<join our mailing list|http://mail.pm.org/mailman/listinfo/perladvent></a></s> L<check the
+perl-advent/Perl-Advent GitHub repo|https://github.com/perladvent/Perl-Advent/> where
 we'll be talking about work that needs to get done on things like the FAQ, the
 site generator, and all that sort of thing.  You can find the L<site's contents
-on GitHub|https://github.com/rjbs/Perl-Advent>, which I<should> contain the
+on GitHub|https://github.com/perl-advent/Perl-Advent>, which I<should> contain the
 2012 articles by the time you see this.  It's not exactly how it should be, but
 it's there.
 
 More importantly, you can find L<our wish list for fixes and
-features|https://github.com/rjbs/Perl-Advent/issues>.  Help with these and you
+features|https://github.com/perl-advent/Perl-Advent/issues>.  Help with these and you
 will earn fame forever (at least in the git logs)!
 
 So until I'm back at Christmas 2013 – if I don't come to my senses and quit
@@ -36,7 +37,6 @@ this job – have a merry Christmas and an excellent new year!
 =head1 See Also
 
 =for :list
-* L<the project issue tracker|https://github.com/rjbs/Perl-Advent>
-* L<the git repository|https://github.com/rjbs/Perl-Advent>
-* L<the mailing list|http://mail.pm.org/mailman/listinfo/perladvent>
+* L<the perl-advent/Perl-Advent GitHub repo|https://github.com/perladvent/Perl-Advent/>
 * L<the someday-to-be-rewritten FAQ|http://www.perladvent.org/FAQ.html>
+* L<the mailing list|http://mail.pm.org/mailman/listinfo/perladvent> (historical archive)

--- a/2013/articles/2013-12-25.pod
+++ b/2013/articles/2013-12-25.pod
@@ -17,12 +17,12 @@ If you want to help with the site or other things in the meantime, you can
 L<join our mailing list|http://mail.pm.org/mailman/listinfo/perladvent> where
 we'll be talking about work that needs to get done on things like the FAQ, the
 site generator, and all that sort of thing.  You can find the L<site's contents
-on GitHub|https://github.com/rjbs/Perl-Advent>, which I<should> contain the
+on GitHub|https://github.com/perl-advent/Perl-Advent>, which I<should> contain the
 2013 articles by the time you see this.  It's not exactly how it should be, but
 it's there.
 
 More importantly, you can find L<our wish list for fixes and
-features|https://github.com/rjbs/Perl-Advent/issues>.  Help with these and you
+features|https://github.com/perl-advent/Perl-Advent/issues>.  Help with these and you
 will earn fame forever (at least in the git logs)!
 
 Whether or not we hear from you between now and then, we look forward to
@@ -32,7 +32,6 @@ Hacking!
 =head1 See Also
 
 =for :list
-* L<the project issue tracker|https://github.com/rjbs/Perl-Advent>
-* L<the git repository|https://github.com/rjbs/Perl-Advent>
-* L<the mailing list|http://mail.pm.org/mailman/listinfo/perladvent>
+* L<the perl-advent/Perl-Advent GitHub repo|https://github.com/perladvent/Perl-Advent/>
 * L<the someday-to-be-rewritten FAQ|http://www.perladvent.org/FAQ.html>
+* L<the mailing list|http://mail.pm.org/mailman/listinfo/perladvent> (historical archive)

--- a/2014/articles/2014-12-25.pod
+++ b/2014/articles/2014-12-25.pod
@@ -58,7 +58,8 @@ that made the advent calendar happen.
 
 As a Perl programmer reading the calendar chances are you have an article in
 you for publishing next year even if you don't know what it is yet.  I
-encourage you to subscribe to the L<mailing list|http://mail.pm.org/mailman/listinfo/perladvent>
+encourage you to <s>subscribe to the L<mailing list|http://mail.pm.org/mailman/listinfo/perladvent></s>
+check the L<perl-advent/Perl-Advent GitHub repo|https://github.com/perladvent/Perl-Advent/>
 where we organize all of this and simply drop us an email saying you'd be
 interested in writing (you'll get a follow up email from me in about eight
 months when we start working out scheduling for 2015.)

--- a/FAQ-submit.mkdn
+++ b/FAQ-submit.mkdn
@@ -2,7 +2,7 @@
 ## Submitting an Article
 
 You should read this page before you start writing an article, and you'll want
-to [join the mailing list](http://mail.pm.org/mailman/listinfo/perladvent) to
+to [open on issue on the perl-advent/Perl-Advent GitHub repo](https://github.com/perladvent/Perl-Advent/issues/new) to
 run your plan by the editor.
 
 ### What's the purpose of the calendar?
@@ -39,8 +39,7 @@ Although most articles in the past are about CPAN modules, we *do* like
 articles about useful programs, programming tricks, and even seemingly-simple
 things like command line options to `perl`.
 
-In short, you should [join the mailing
-list](http://mail.pm.org/mailman/listinfo/perladvent) and ask about your idea
+In short, you should [visit the perl-advent/Perl-Advent GitHub repo](https://github.com/perladvent/Perl-Advent) and ask about your idea
 there!
 
 ### What format should I write in?

--- a/contact.mkdn
+++ b/contact.mkdn
@@ -1,5 +1,5 @@
 #  Perl Advent Calendar
 ## Contact Information
 
-The best way to contact the people who run the calendar is to email
-`perladvent@perl.org`, which is a mailing list.
+The best way to contact the people who run the calendar is through
+the [perladvent/Perl-Advent GitHub repo](https://github.com/perladvent/Perl-Advent/)


### PR DESCRIPTION
Stikeout references to the mailing list and add a pointer to the GitHub repo. This retconning makes the text seem a bit weird in places, but I think changing things too much is also weird since we changing the historical record.

This also updates all the GitHub pointer to go to perl-advent/Perl-Advent instead of any other repo used in the past.