### PR TITLE
Fix remaining bad legacy links in #237

### DIFF
--- a/2000/15/index.html
+++ b/2000/15/index.html
@@ -441,7 +441,7 @@ messages. For example:</P>
     useful with the contents thereof.</PRE>
 <PRE>
     =cut</PRE>
-<P>See <A HREF="/Pod/Usage.html">the Pod::Usage manpage</A> for details.</P>
+<P>See <A HREF="https://metacpan.org/pod/Pod::Usage">the Pod::Usage manpage</A> for details.</P>
 <P>
 <H2><A NAME="storing options in a hash">Storing options in a hash</A></H2>
 <P>Sometimes, for example when there are a lot of options, having a

--- a/2000/20/index.html
+++ b/2000/20/index.html
@@ -144,7 +144,7 @@ At this point <CODE>Inline</CODE> knows it needs to compile the source code. The
 <PRE>
      1) $ENV{PERL_INLINE_BLIB}
         (The PERL_INLINE_BLIB environment variable overrides all else)
-     2) ./blib_I/  
+     2) ./blib_I/
         (The current directory, unless you're in your home directory)
      3) $bin/blib_I/
         (Where '$bin' is the directory that the script is in)
@@ -154,13 +154,13 @@ At this point <CODE>Inline</CODE> knows it needs to compile the source code. The
         (Same as above but more discrete)</PRE>
 <P>If none of those exist, Inline will attempt to create and use one of following:</P>
 <PRE>
-     6) $bin/blib_I/ 
+     6) $bin/blib_I/
      7) ./blib_I/</PRE>
-<P>Failing that, Inline will croak. Optionally, you can configure <CODE>Inline</CODE> to build and install exactly where you want, using <CODE>Inline::Config</CODE>. See <A HREF="/Inline/Config.html">the Inline::Config manpage</A>.
+<P>Failing that, Inline will croak. Optionally, you can configure <CODE>Inline</CODE> to build and install exactly where you want, using <CODE>Inline::Config</CODE>. See <A HREF="https://fastapi.metacpan.org/source/INGY/Inline-0.26/lib/Inline/Config.pod">the Inline::Config manpage</A>.
 </P>
 <PRE>
 
-If C&lt;$Inline::Config::SITE_INSTALL=1&gt;, then C&lt;Inline&gt; will only use C&lt;./blib_I/&gt; to build in, and the C&lt;$Config{installsitearch}&gt; directory to install the executable in. This option is intended to be used in modules that are to be distributed on the CPAN, so that they get installed in the proper place.</PRE>
+If <CODE>$Inline::Config::SITE_INSTALL=1</CODE>, then <CODE>Inline</CODE> will only use <CODE>./blib_I/</CODE> to build in, and the <CODE>$Config{installsitearch}</CODE> directory to install the executable in. This option is intended to be used in modules that are to be distributed on the CPAN, so that they get installed in the proper place.</PRE>
 <P>Optionally, you can configure <CODE>Inline</CODE> to build and install exactly where you want.</P>
 <P><STRONG>NOTE</STRONG>: <CODE>blib</CODE> stands for ``build library'' in Perl-speak. It is a directory that gets created when you install a Perl module on your system. <CODE>blib_I</CODE> is the <CODE>Inline.pm</CODE> version of the same concept.</P>
 <P></P>
@@ -224,7 +224,7 @@ By default, <CODE>Inline</CODE> will remove all of the mess created by the build
 <PRE>
 
     use Inline C =&gt; &quot;C code goes here...&quot;;</PRE>
-<P>See <A HREF="/Inline/Config.html">the Inline::Config manpage</A> for more info.</P>
+<P>See <A HREF="https://fastapi.metacpan.org/source/INGY/Inline-0.26/lib/Inline/Config.pod">the Inline::Config manpage</A> for more info.</P>
 <P>
 <H2><A NAME="configuration from the command line">Configuration from the Command Line</A></H2>
 <P><CODE>Inline</CODE> lets you set many of the configuration options from the command line. This can be very handy, especially when you only want to set the options temporarily, for say, debugging.</P>
@@ -240,7 +240,7 @@ By default, <CODE>Inline</CODE> will remove all of the mess created by the build
 <P>or better yet:</P>
 <PRE>
     perl -MInline=INFO,FORCE Foo.pl</PRE>
-<P>See <A HREF="/Inline/Config.html">the Inline::Config manpage</A> for more info.</P>
+<P>See <A HREF="https://fastapi.metacpan.org/source/INGY/Inline-0.26/lib/Inline/Config.pod">the Inline::Config manpage</A> for more info.</P>
 <P>
 <H2><A NAME="writing modules with inline">Writing Modules with Inline</A></H2>
 <P>Writing CPAN modules that use other programming languages is easy with <CODE>Inline</CODE>. Let's say that you wanted to write a module called <CODE>Math::Simple</CODE> using the previous example code. Start by using the following command:</P>
@@ -332,12 +332,12 @@ By default, <CODE>Inline</CODE> will remove all of the mess created by the build
 <P><STRONG>NOTE</STRONG>: <CODE>Inline.pm</CODE> requires Perl 5.005 or higher because <CODE>Parse::RecDescent</CODE> requires it. (Something to do with the <CODE>qr</CODE> operator)</P>
 <P>Inline has been tested on the following platforms:</P>
 <PRE>
- V#   OS      OS V#   Perl V# Human              Email 
+ V#   OS      OS V#   Perl V# Human              Email
  0.25 Linux   2.2.13  5.00503 Brian Ingerson     ingy@cpan.org
  0.25 Linux   2.2.13  5.6     Brian Ingerson     ingy@cpan.org
- 0.20 FreeBSD 3.4     5.00503 Timothy A Gregory  tgregory@tarjema.com      
- 0.20 FreeBSD 4.0     5.00503 Timothy A Gregory  tgregory@tarjema.com      
- 0.20 FreeBSD 4.0     5.6     Timothy A Gregory  tgregory@tarjema.com      
+ 0.20 FreeBSD 3.4     5.00503 Timothy A Gregory  tgregory@tarjema.com
+ 0.20 FreeBSD 4.0     5.00503 Timothy A Gregory  tgregory@tarjema.com
+ 0.20 FreeBSD 4.0     5.6     Timothy A Gregory  tgregory@tarjema.com
  0.20 Linux   2.0.36  5.00503 Prakasa Bellam     pbellam@cobaltgroup.com
  0.20 HPUX    B.10.20 5.00503 Jamie Shaffer      jshaffer@chronology.com
  0.20 SunOS   5.6     5.6.0   Jamie Shaffer      jshaffer@chronology.com
@@ -364,7 +364,7 @@ By default, <CODE>Inline</CODE> will remove all of the mess created by the build
 <P>
 <HR>
 <H1><A NAME="see also">SEE ALSO</A></H1>
-<P><A HREF="/Inline/Config.html">the Inline::Config manpage</A> and <A HREF="/Inline/C/Tutorial.html">the Inline::C::Tutorial manpage</A></P>
+<P><A HREF="https://fastapi.metacpan.org/source/INGY/Inline-0.26/lib/Inline/Config.pod">the Inline::Config manpage</A> and <A HREF="/Inline/C/Tutorial.html">the Inline::C::Tutorial manpage</A></P>
 <P>
 <HR>
 <H1><A NAME="bugs and deficiencies">BUGS AND DEFICIENCIES</A></H1>


### PR DESCRIPTION
One link goes to Pod::Usage, and the others for Inline have to deep link to old distros that still have the module.