### PR TITLE
Remove splash screen as part of CI site build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - 'main'
   schedule:
     - cron: '0 0 1-27 12 *'  # December 1-27 (usually 1-25)
+    - cron: '0 0 1 2 *'      # Feb 1 (replace placeholder screen)
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -51,6 +52,9 @@ jobs:
 
       - name: 📚 Build articles
         run: bash script/build-site.sh
+
+      - name: 👉 Remove placeholder screen in Dec and Jan
+        run: bash script/deploy/splash-screen.sh
 
       - name: Set up pages
         uses: actions/configure-pages@v2

--- a/in-season.html
+++ b/in-season.html
@@ -1,0 +1,8 @@
+<!-- use this redirect splash screen in December and January -->
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; URL=2023" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/script/deploy/splash-screen.sh
+++ b/script/deploy/splash-screen.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# If this is December or January, replace the placeholder screen
+if [[ $(date +%m) -eq 12 ]] || [[ $(date +%m) -eq 1 ]]; then
+  cp in-season.html index.html
+fi


### PR DESCRIPTION
- Automate removal of splash screen when a new calendar is live
- Rebuild site on Feb 1 in order to restore placeholder screen
