### PR TITLE
Clean up a link and link checking

### DIFF
--- a/2019/articles/2019-12-17.pod
+++ b/2019/articles/2019-12-17.pod
@@ -3,7 +3,7 @@ Topic: AWS::Lambda::PSGI
 Author: Mark Fowler <mark@twoshortplanks.com>
 
 The Wise Old Elf was very impressed how Sugarplum Snoozysnaps had
-L<saved Christmas|http://perladvent.org/2019/2019-12-15.html|> this year by moving some code to AWS Lambda at the last
+L<saved Christmas|http://perladvent.org/2019/2019-12-15.html> this year by moving some code to AWS Lambda at the last
 moment.  So impressed that he wanted her to investigate how it could
 be used to do more.
 

--- a/script/check-site.pl
+++ b/script/check-site.pl
@@ -92,6 +92,7 @@ my $robocop = WWW::RoboCop->new(
 
         return 0 if $limit > $upper_limit;
         my $uri = URI->new( $link->url_abs );
+        return 0 unless $uri->can('host'); # skip mailto
 
         # If the link URI does not match the host but the referring_url matches
         # the host, then this is a 1st degree outbound link.  If outbound link


### PR DESCRIPTION
- Skip mailto links in link checker
- Remove stray character from link in 2019-12-17
