### PR TITLE
Fix overflow in pre blocks

### DIFF
--- a/2023/2023.css
+++ b/2023/2023.css
@@ -242,6 +242,7 @@ pre {
   color: #ffffff;
   font-family: monospace;
   width: 100%;
+  overflow: auto;
 }
 
 .code-listing {


### PR DESCRIPTION
This change will make the overflow pre block look like this: 
![image](https://github.com/perladvent/Perl-Advent/assets/44323413/9f6d1de7-3c35-439a-9d76-a53f2846069d)

(notice the horizontal scroll)

There should be no change if the block content does not overflow.