### PR TITLE
Bitcoin articles: Replace code snippet tabs with double spaces

### DIFF
--- a/2023/articles/2023-12-02.pod
+++ b/2023/articles/2023-12-02.pod
@@ -61,15 +61,15 @@ use Bitcoin::Crypto qw(btc_prv btc_utxo);
 
 # first, import the 50 BTC output from previous transaction hex
 btc_utxo->extract([hex => '
-	010000000100000000000000000000
-	000000000000000000000000000000
-	00000000000000ffffffff07045285
-	021b0151ffffffff0100f2052a0100
-	000043410452b58be18046f78a0045
-	fe49df56387a03f994ba2ac7a26e17
-	f7d01dc6d346f1bed3979ad35d32a7
-	5bb625f6e521f75a1c5983d303ea04
-	bfb43c8b72203a68eeac00000000
+  010000000100000000000000000000
+  000000000000000000000000000000
+  00000000000000ffffffff07045285
+  021b0151ffffffff0100f2052a0100
+  000043410452b58be18046f78a0045
+  fe49df56387a03f994ba2ac7a26e17
+  f7d01dc6d346f1bed3979ad35d32a7
+  5bb625f6e521f75a1c5983d303ea04
+  bfb43c8b72203a68eeac00000000
 ']);
 
 # second, import the private key to these BTC
@@ -130,24 +130,24 @@ my $number_of_kids = 346;
 
 # get the master key for the BIP44 account with purpose 84
 my $account_key = $master_key->derive_key_bip44(
-	purpose => 84,
-	get_account => !!1,
-	account => 0, # to be bumped up next Christmas!
+  purpose => 84,
+  get_account => !!1,
+  account => 0, # to be bumped up next Christmas!
 );
 
 # get the basic private key for the unused coins
 my $change_key = $account_key->derive_key_bip44(
-	get_from_account => !!1,
-	change => 1,
-	index => 0,
+  get_from_account => !!1,
+  change => 1,
+  index => 0,
 )->get_basic_key;
 
 # get basic keys for all the kids!
 my @kids_keys = map {
-	$account_key->derive_key_bip44(
-		get_from_account => !!1,
-		index => $_,
-	)->get_basic_key
+  $account_key->derive_key_bip44(
+    get_from_account => !!1,
+    index => $_,
+  )->get_basic_key
 } 0 .. $number_of_kids - 1;
 
 =end perl
@@ -167,15 +167,15 @@ my $tx = btc_transaction->new;
 
 # add the input from the UTXO
 $tx->add_input(
-	utxo => [[hex => 'a4e407ba6b54106e4bd209704666a2b541b9b03d04ef8cb779aafe18238744e1'], 0],
+  utxo => [[hex => 'a4e407ba6b54106e4bd209704666a2b541b9b03d04ef8cb779aafe18238744e1'], 0],
 );
 
 # add all the gift outputs
 foreach my $key (@kids_keys) {
-	$tx->add_output(
-		locking_script => [address => $key->get_public_key->get_address],
-		value => 100_000,
-	);
+  $tx->add_output(
+    locking_script => [address => $key->get_public_key->get_address],
+    value => 100_000,
+  );
 }
 
 =end perl
@@ -199,8 +199,8 @@ my $change_value = $currently_unspent - $wanted_fee;
 
 # add the change output as the last output of the transaction
 $tx->add_output(
-	locking_script => [address => $change_key->get_public_key->get_address],
-	value => $change_value,
+  locking_script => [address => $change_key->get_public_key->get_address],
+  value => $change_value,
 );
 
 # set replace-by-fee

--- a/2023/articles/2023-12-03.pod
+++ b/2023/articles/2023-12-03.pod
@@ -42,15 +42,15 @@ my $number_of_kids = 346;
 # print all the keys in WIF format
 foreach my $index (0 .. $number_of_kids - 1) {
 
-	# same derivation scheme as before
-	my $key = $master_key->derive_key_bip44(
-		purpose => 84,
-		account => 0,
-		index => $index,
-	)->get_basic_key;
+  # same derivation scheme as before
+  my $key = $master_key->derive_key_bip44(
+    purpose => 84,
+    account => 0,
+    index => $index,
+  )->get_basic_key;
 
-	# print it to standard output
-	say $key->to_wif;
+  # print it to standard output
+  say $key->to_wif;
 }
 
 =end perl


### PR DESCRIPTION
There are some problems with viewing tab characters in the second article, so I replaced tabs with double spaces in both articles.