### PR TITLE
Correct hyperlinks to MongoDB and ArangoDB

### DIFF
--- a/2023/articles/2023-12-06.pod
+++ b/2023/articles/2023-12-06.pod
@@ -9,8 +9,8 @@ Author: Alberto Simões <ambs@cpan.org>
 =head2 Introduction
 
 L<Arango::Tango> is not properly new, as the first versions are from 2019. Nevertheless, the number of users is still quite small as 
-other document-oriented databases, like L<ElasticSearch|https://www.elastic.co/> or C<MongoDB|https://www.mongodb.com/> are still quite
-popular. But being somehow alergic to Java, I went in the search for an alternative and found C<ArangoDB|https://arangodb.com/>, a graph
+other document-oriented databases, like L<ElasticSearch|https://www.elastic.co/> or L<MongoDB|https://www.mongodb.com/> are still quite
+popular. But being somehow alergic to Java, I went in the search for an alternative and found L<ArangoDB|https://arangodb.com/>, a graph
 database (also able to deal with plain document collections) written in C++.
 
 ArangoDB is a graph-oriented database, making it particularly well-suited for storing network structures such as social networks,


### PR DESCRIPTION
These were done as code, not hyperlinks.