### PR TITLE
Fix a typo: Arango mentioned instead of Mongo

### DIFF
--- a/2023/articles/2023-12-06.pod
+++ b/2023/articles/2023-12-06.pod
@@ -16,7 +16,7 @@ database (also able to deal with plain document collections) written in C++.
 ArangoDB is a graph-oriented database, making it particularly well-suited for storing network structures such as social networks,
 knowledge graphs, and geospatial information. To achieve this, ArangoDB utilizes two collections: one for nodes and another for edges.
 The nodes collection functions as a standard database of documents, similar to what you would find in MongoDB. Meanwhile, the edges collection
-has documents containing two special attributes: the origin and target nodes, identified by their document identifiers. Unlike ArangoDB and
+has documents containing two special attributes: the origin and target nodes, identified by their document identifiers. Unlike MongoDB and
 ElasticSearch, ArangoDB employs a specific Domain-Specific Language for queries. However, unlike the former two, ArangoDB's query language,
 named AQL (ArangoDB Query Language), is not based on JSON. This distinction makes AQL easier to write and understand.
 


### PR DESCRIPTION
At least I hope that's what @ambs meant.