### PR TITLE
Let people build and deploy perladvent on their fork

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
   build:
     name: Build and deploy site
     runs-on: ubuntu-latest
-    if: github.repository == 'perladvent/Perl-Advent'
     container:
       image: perldocker/perl-tester:5.38
     steps:


### PR DESCRIPTION
# Let people build and deploy perladvent on their fork
It allows people to easily preview like [this](https://thibaultduponchelle.github.io/Perl-Advent/) (from [my fork](https://github.com/thibaultduponchelle/Perl-Advent)) with just few steps (enable pages in settings, enable actions, start one run)

# More
This change conflicts with #256 and #250

I think in 2023 (hence after @openstrike issue and pull request), GitHub made forking disable automatically the workflows on the fork at creation.

Now, when forking, actions are disabled by default:
![pa-actions-not-enabled](https://github.com/perladvent/Perl-Advent/assets/580360/becd2def-d24b-4c68-b1ae-656095defd5d)

Even after enabling workflows, we still need to enable `on: schedule` workflows:
![pa-disabled-workflow](https://github.com/perladvent/Perl-Advent/assets/580360/da71049e-846c-4e2d-8db4-b0db018ddfc9)
(and scheduled workflows will be disabled after some time)

Also, it's still possible to disable actions later:
![pa-disable-actions](https://github.com/perladvent/Perl-Advent/assets/580360/ad286e17-889a-4dfc-9f9f-ff8e06abd6a6)

For all these reasons, I think dropping this line would add much more value than harm.