### PR TITLE
Some little edits to 1999 non reg

### DIFF
--- a/1999/articles/1999-12-01.pod
+++ b/1999/articles/1999-12-01.pod
@@ -1,4 +1,4 @@
-Author: thibault.duponchelle@gmail.com
+Author: Thibault DUPONCHELLE <thibault.duponchelle@gmail.com>
 Title: Testing formatting
 Topic: perl
 

--- a/1999/articles/1999-12-02.pod
+++ b/1999/articles/1999-12-02.pod
@@ -1,4 +1,4 @@
-Author: thibault.duponchelle@gmail.com
+Author: Thibault DUPONCHELLE <thibault.duponchelle@gmail.com>
 Title: Testing code
 Topic: perl
 
@@ -29,7 +29,7 @@ A C<perl> section can do syntax highlighting
 
 # Syntax-highlighted code
 my $x = 1_00_000 ** $::xyzzy;
-my $long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+my $long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 =end perl
 
@@ -38,6 +38,6 @@ my $long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 Verbatim text
 
 	my $x = 1_00_000 ** $::xyzzy;
-        my $long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+	my $long_str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 =cut

--- a/1999/articles/1999-12-03.pod
+++ b/1999/articles/1999-12-03.pod
@@ -1,4 +1,4 @@
-Author: thibault.duponchelle@gmail.com
+Author: Thibault DUPONCHELLE <thibault.duponchelle@gmail.com>
 Title: Testing images
 Topic: perl
 

--- a/1999/articles/1999-12-04.pod
+++ b/1999/articles/1999-12-04.pod
@@ -1,4 +1,4 @@
-Author: thibault.duponchelle@gmail.com
+Author: Thibault DUPONCHELLE <thibault.duponchelle@gmail.com>
 Title: Testing embedded HTML
 Topic: perl
 


### PR DESCRIPTION
# Changes
- Longer string to be sure to overflow (without zoom)
- Author name following normal convention