### PR TITLE
Show vim syntax hints in script/new_article

### DIFF
--- a/2024/incoming/santas-reindeer.pod
+++ b/2024/incoming/santas-reindeer.pod
@@ -18,6 +18,8 @@ One file, F<donner.json>, has this data:
 
 =begin code
 
+#!vim json
+
 	{
 	"Name": "Donner",
 	"aliases": [ "Dunder", "Donder" ],
@@ -30,6 +32,8 @@ Another file, F<rudolph.json>, has similar data but with slightly different
 field names and a different date format:
 
 =begin code
+
+#!vim json
 
 	{
 	"name": "Rudolph",
@@ -262,6 +266,8 @@ create that data structure can be its source. For example, Santa could
 put it in a YAML file:
 
 =begin code
+
+#!vim yaml
 
 	---
 	type: '//rec'

--- a/2024/incoming/santas-reindeer.pod
+++ b/2024/incoming/santas-reindeer.pod
@@ -1,0 +1,307 @@
+Author: brian d foy <briandfoy@pobox.com>
+Title: Santa's Naughty and Nice Data Formats
+Topic: Data::Rx
+
+=encoding utf8
+
+=head2 Santa's Naughty and Nice Data Formats
+
+Santa faces a technology issue that many of us has faced. After a
+succession of elves half-implemented a reindeer tracking system, his
+reindeer database is in a sad state. He needs to fix it up some he can
+generate those reports his compliance elves keep hassling him about.
+That same compliance team also makes Santa use source control, so
+his L<data and programs are in
+GitHub|https://github.com/briandfoy/santas-reindeers-rx-perl-advent-2024>.
+
+One file, F<donner.json>, has this data:
+
+=begin code
+
+	{
+	"Name": "Donner",
+	"aliases": [ "Dunder", "Donder" ],
+	"start-date": "1823-12-24"
+	}
+
+=end code
+
+Another file, F<rudolph.json>, has similar data but with slightly different
+field names and a different date format:
+
+=begin code
+
+	{
+	"name": "Rudolph",
+	"start_date": "12/24/1939"
+	}
+
+=end code
+
+Either different elves worked on these files or one elf
+forget simply chose different names for the next file. Not for nothing,
+but Santa has experienced what many people have experienced: the stew of ideas,
+opinions, and bugs that make up legacy database design (and present
+designs that will become future legacy designs).
+
+=head2 Enter Data::Rx
+
+At first this seems like a simple problem of checking each hash
+to ensure it has the right set of keys. The same goes for its values.
+But, as the data structure gets more and more complicated, so does
+the code.
+
+L<Data::Rx> provides a way to declare what a data structure should
+look like and what sort of values it should have. Santa starts with
+a simple script. He know it's going to take a minute to clean up all
+of his files, so he'll start with two things he knows. He wants the
+fields to be C<name> and C<start_date>:
+
+=begin perl
+
+	use v5.14;
+
+	use Data::Rx;
+	use Mojo::File;
+	use Mojo::JSON;
+
+	my $record = {
+		type     => '//rec',
+		required => {
+			name       => { type => '//str' },
+			start_date => { type => '//str' },
+			},
+		};
+
+	my $rx = Data::Rx->new;
+	my $schema = $rx->make_schema($record);
+
+	foreach my $file ( sort @ARGV ) {
+		say "Checking $file";
+
+		my $data = eval { Mojo::JSON::decode_json( Mojo::File->new($file)->slurp ) };
+		unless( $data ) {
+			my $error = $@ =~ s/\.^/\n/gmr;
+			say "\tCould not read <$file>: $error";
+			next;
+			}
+
+		eval { $schema->assert_valid($data) };
+		my $at = $@;
+		next unless length $at;
+
+		foreach my $failure ( @{ $at->failures } ) {
+			say "\t$failure";
+			}
+		};
+
+=end perl
+
+Santa runs his progam on a couple of the files to see some errors.
+There are some misnamed field which show up as both unexpected entries
+and missing values for required entries:
+
+	$ perl bin/validate data/rudolph.json data/donner.json
+	Checking data/donner.json
+		Failed //rec: found unexpected entries: Name aliases start-date (error: unexpected at $data)
+		Failed //rec: no value given for required entry start_date (error: missing at $data)
+		Failed //rec: no value given for required entry name (error: missing at $data)
+	Checking data/rudolph.json
+
+=head2 The Rx Language
+
+The L<https://rx.codesimply.com|Rx language> allows Santa to easily
+specify basic structure as well as extend it for more complex types. The
+L<Data::Rx> module implements this for Perl, but the language can be
+implemented in anything.
+
+In Perl, this starts with hash with the key C<type> to specify what
+the first element should be. In this case, the type is C<//rec>, the
+Rx name for a hash (dictionary, map, JSON object, and so on):
+
+=begin perl
+
+	my $record = {
+		type => '//rec',
+		};
+
+=end perl
+
+There are many other types, but at the top level you probably have
+a C<//rec>, C<//arr> (array), C<//map> (all values are the same type),
+or a C<//seq> (sequence).
+
+Next, Santa can specify the required keys, and specify the value that
+each of these keys takes. Each of the values is another Rx specification,
+and in this case, each of them are strings (C<//str>):
+
+=begin perl
+
+	my $record = {
+		type     => '//rec',
+		required => {
+			name       => { type => '//str' },
+			start_date => { type => '//str' },
+			},
+		};
+
+=end perl
+
+Once Santa has his schema, he tells L<Data::Rx> to create the Perl
+object he can use to validate the data:
+
+=begin perl
+
+	my $rx = Data::Rx->new;
+	my $schema = $rx->make_schema($record);
+
+=end perl
+
+To apply the schema to a Perl data structure, Santa calls C<assert_valid>,
+which throws an exception if the validation fails:
+
+=begin perl
+
+	eval { $schema->assert_valid($data) };
+
+=end perl
+
+There's also a binary C<check>, but that doesn't report the errors.
+
+=head2 Fixing the data errors
+
+Santa fixes up the field names easily enough, but to handle C<aliases>
+he needs to specify an array. In Rx, an array has values that are all
+the same type (say, all strings). Santa extends his specification a little:
+
+=begin perl
+
+	my $record = {
+		type     => '//rec',
+		required => {
+			name       => { type => '//str' },
+			start_date => { type => '//str' },
+			},
+		optional => {
+			aliases => {
+				type => '//arr',
+				contents => '//str'
+				}
+			},
+		};
+
+=end perl
+
+Now both files validate:
+
+	$ perl bin/validate data/rudolph.json data/donner.json
+	Checking data/donner.json
+	Checking data/rudolph.json
+
+=head2 XXX
+
+Santa still has a problem because the date formats in his two test
+records don't match. The values are both strings, but that's it.
+
+To make his own type, Santa defines a new package that inherits from
+L<Data::Rx::CommonType::EasyNew>. This package defines C<type_uri>,
+which is the name for the new type, and C<assert_valid>, which is the
+Perl subroutine that calls C<fail> with the parts that L<Data::Rx>
+needs to report the error:
+
+=begin perl
+
+	package Reindeer::YYYYMMDD {
+		use parent 'Data::Rx::CommonType::EasyNew';
+
+		sub type_uri {
+			'tag:example.com,EXAMPLE:rx/reindeer-date',
+			}
+
+		sub assert_valid {
+			my ($self, $value) = @_;
+			return 1 unless defined $value;
+			$value =~ /\A(?:\d\d\d\d)-\d\d-\d\d\z/a or $self->fail({
+				error => [ qw(type) ],
+				message => "date value is not YYYY-MM-DD",
+				value => $value,
+				})
+			}
+		}
+
+=end perl
+
+To use this new type, Santa loads it as part of the call to C<new>:
+
+=begin perl
+
+	my $rx = Data::Rx->new({
+	  type_plugins => [qw(
+		Reindeer::YYYYMMDD
+	  )],	});
+
+=end perl
+
+Now Santa's program catches the date format error:
+
+	$ perl bin/validate data/rudolph.json data/donner.json
+	Checking data/donner.json
+	Checking data/rudolph.json
+		Failed tag:example.com,EXAMPLE:rx/reindeer-date: date value is not YYYY-MM-DD (error: type at $data->{start_date})
+
+Santa didn't have to change anything in the meat of his program. Everything
+in the C<foreach> loop stayed the same and he only has the change the
+Rx specification. I write about this sort of thing quite a bit in
+L<Effective Perl Programming|https://www.effectiveperlprogramming.org/>
+and L<Mastering Perl|https://www.masteringperl.org/>.
+
+=head2 The schema as configuration
+
+Since Santa's L<Data::Rx> schema is really a data structure, anything that can
+create that data structure can be its source. For example, Santa could
+put it in a YAML file:
+
+=begin code
+
+	---
+	type: '//rec'
+	required:
+		name:
+			type: '//str'
+		start_date:
+			type: 'tag:example.com,EXAMPLE:rx/reindeer-date'
+	optional:
+		aliases:
+			type: '//arr'
+			contents: '//str'
+
+=end code
+
+In Santa's program, he loads his schema with the L<YAML> module.
+
+=begin perl
+
+	use YAML;
+
+	my $record = YAML::LoadFile( 'rx.yml' );
+
+=end perl
+
+By having the schema outside of the Perl source, Santa can reuse it
+with other tools. So far, Rx has only very limited support for custom
+types, so those parts still have to live in code.
+
+=head2 Final words
+
+XXX.
+
+=head2 Further Reading
+
+=for :list
+* L<The Rx language|https://rx.codesimply.com>
+* L<The Data::Rx module|https://metacpan.org/pod/Data::Rx>
+* L<Santa's GitHub repo|https://github.com/briandfoy/santas-reindeers-rx-perl-advent-2024>
+* L<The History of Santa's Reindeer|https://www.altogetherchristmas.com/traditions/reindeer.html>
+* L<The Running Reindeer Ranch|https://runningreindeer.com>
+
+=cut

--- a/script/new_article
+++ b/script/new_article
@@ -115,6 +115,22 @@ A C<code> section can syntax-highlight non-Perl too:
 
 =end code
 
+You can try vim syntax highlighting hints, such as declaring that a
+snippet is JSON:
+
+=begin code
+
+#!vim json
+
+	{
+	"Name": "Donner",
+	"aliases": [ "Dunder", "Donder" ],
+	"start-date": "1823-12-24"
+	}
+
+=end code
+
+
 =head2 Raw HTML
 
 Include some raw HTML. A blank line breaks the spell:

--- a/script/new_article
+++ b/script/new_article
@@ -116,12 +116,12 @@ A C<code> section can syntax-highlight non-Perl too:
 =end code
 
 You can try vim syntax highlighting hints, such as declaring that a
-snippet is JSON:
+snippet is JSON. The hint is the first line and indented at the same
+level.
 
 =begin code
 
-#!vim json
-
+	#!vim json
 	{
 	"Name": "Donner",
 	"aliases": [ "Dunder", "Donder" ],


### PR DESCRIPTION
@oalders mentioned this in #444, so here's a patch for the *new_article* script. We should still verify that this actually works. I've made a change in my article from that issue to use this trick.