### PR TITLE
Show vim syntax hints in new_article

### DIFF
--- a/script/new_article
+++ b/script/new_article
@@ -115,6 +115,22 @@ A C<code> section can syntax-highlight non-Perl too:
 
 =end code
 
+You can try vim syntax highlighting hints, such as declaring that a
+snippet is JSON. The hint is the first line and indented at the same
+level.
+
+=begin code
+
+	#!vim json
+	{
+	"Name": "Donner",
+	"aliases": [ "Dunder", "Donder" ],
+	"start-date": "1823-12-24"
+	}
+
+=end code
+
+
 =head2 Raw HTML
 
 Include some raw HTML. A blank line breaks the spell:


### PR DESCRIPTION
This is a do over for #446 that only has the changes to *new_article*