### PR TITLE
Format Perl examples using `=begin perl` in `Ref::Util` post

### DIFF
--- a/2024/articles/2024-12-03.pod
+++ b/2024/articles/2024-12-03.pod
@@ -16,9 +16,13 @@ If L<Ref::Util> sounds familiar, it might be thanks to the L<Perl Advent Calenda
 
 In the days of yore, you might have found yourself writing code like:
 
+=begin perl
+
     if ( ref $sleigh eq 'HASH' ) {
         load_presents($sleigh);
     }
+
+=end perl
 
 But alas! This is like finding coal in your stocking. 🎄 By using C<ref $sleigh eq 'HASH'>, we're peeking behind the curtains, exposing Perl's internal workings. We're grabbing the string representation of a reference and hoping it matches our expectations. If C<$sleigh> isn't a reference at all, C<ref> returns an empty string — leaving us out in the cold. (At least it's not C<undef>, which would likely wreak havoc during runtime).
 
@@ -26,11 +30,15 @@ But alas! This is like finding coal in your stocking. 🎄 By using C<ref $sleig
 
 Enter L<Ref::Util>, our festive hero that's been around for a while but might not have made it onto your wish list yet! With it, we can rewrite our code as:
 
+=begin perl
+
     use Ref::Util qw< is_hashref >;
 
     if ( is_hashref($sleigh) ) {
         load_presents($sleigh);
     }
+
+=end perl
 
 Isn't that as refreshing as a winter's first snow? ❄️  The code is cleaner and more readable, but the true magic lies beneath the surface. L<Ref::Util> doesn't just sprinkle a bit of tinsel on your code — it B<supercharges> it! L<Ref::Util> even provides a sleigh full of functions to check all sorts of references:
 
@@ -84,18 +92,26 @@ This comprehensive suite lets you check for any type of reference without exposi
 
 Example:
 
+=begin perl
+
     use Ref::Util qw< is_blessed_arrayref >;
 
     if ( is_blessed_arrayref($elves) ) {
         assign_tasks($elves);
     }
 
+=end perl
+
 Instead of:
+
+=begin perl
 
     use Scalar::Util qw< blessed reftype >;
     if ( ref_type($elves) eq 'ARRAY' && blessed($elves) ) {
         assign_tasks($elves);
     }
+
+=end perl
 
 (You might consider calling C<blessed($elves) eq 'ARRAY'> but that doesn't differentiate between package name and reference type.)
 


### PR DESCRIPTION
Hi,

Upon opening today's entry, I noticed that the code examples were lacking syntax highlighting, which – at least in my opinion – makes them harder to read. This PR fixes that by using `=begin perl` blocks. Perhaps the leading indentation should be removed, too; I'm not that familiar with POD. Thanks for the calendar; Happy advent!