### PR TITLE
switched satellite data listing to using verbatim mode

### DIFF
--- a/2024/articles/2024-12-21.pod
+++ b/2024/articles/2024-12-21.pod
@@ -47,8 +47,6 @@ The data format of the positional satellites consisted of their positions in
 latitude, longitude, with an altitude; so the computations are necessarily in
 3D space, and could contain any number of lines:
 
-=begin data
-
   39.2497677581748 -66.1173923826129 29161.8658117126
   -39.9677413540029 -41.3796046007432 23577.9949741844
   82.2366387689737 153.417562140013 20022.1066827945
@@ -78,8 +76,6 @@ latitude, longitude, with an altitude; so the computations are necessarily in
   8.56759320194605 14.0242190926548 24229.1350707098
   89.3116725410715 19.3710347706399 28181.9446348641
   ...
-
-=end data
 
 The distance formula was computationally expensive, involving square roots and
 trigonometry. But by using OpenMP, the task could be split into multiple OS


### PR DESCRIPTION
Removed `=begin data` so verbatim mode can take over for satellite location data example