### PR TITLE
Fix a typo in the C<< ... >> construct in the XML::Twig article

### DIFF
--- a/2024/articles/2024-12-09.pod
+++ b/2024/articles/2024-12-09.pod
@@ -60,7 +60,7 @@ you want to parse a string that contains whole XML document then you could use C
 
 
 In order to access guest tags, we first need to obtain guestList, which is the root of this
-XML document. The C<<$twig->root>> method returns the direct parent of all other elements. On the
+XML document. The C<< $twig->root >> method returns the direct parent of all other elements. On the
 other hand, the C<children> method returns list of elements. The method can take an optional
 argument. If a string is passed to the method, XML elements that match the string will be fetched;
 otherwise, all elements of the current root will be fetched in document order. The returned list


### PR DESCRIPTION
C<< ... >> needs spaces around its argument.
