### PR TITLE
Extend archives to include articles from 2024

### DIFF
--- a/archives.yaml
+++ b/archives.yaml
@@ -1178,3 +1178,61 @@
   - { "module" : "FFI::Platypus" }
   25:
   - { "module" : "Date::Christmas" }
+
+2024:
+  01:
+  - { "module" : "MooseX::Extended" }
+  02:
+  - { "module" : "HTTP::XSHeaders" }
+  - { "module" : "URI::XSEscape" }
+  - { "module" : "HTTP::XSCookies" }
+  03:
+  - { "module" : "Ref::Util" }
+  04:
+  - { "topic" : "GitHub Actions" }
+  05:
+  - { "module" : "Data::Rx" }
+  06:
+  - { "module" : "OpenAI::API" }
+  07:
+  - { "module" : "Parallel::ForkManager" }
+  08:
+  - { "module" : "Feature::Compat::Class" }
+  09:
+  - { "module" : "XML::Twig" }
+  10:
+  - { "module" : "e" }
+  11:
+  - { "module" : "Map::Tube" }
+  12:
+  - { "topic" : "Methodology" }
+  - { "topic" : "standups" }
+  - { "topic" : "mental health" }
+  - { "module" : "Object::Pad" }
+  - { "module" : "App::Standup::Diary" }
+  13:
+  - { "module" : "Net::Clacks" }
+  14:
+  - { "module" : "Valiant" }
+  15:
+  - { "topic" : "GitHub actions" }
+  16:
+  - { "module" : "Inline::C" }
+  17:
+  - { "topic" : "Natural Language Processing" }
+  - { "topic" : "Graph Visualisation" }
+  18:
+  - { "topic" : "OpenTelemetry" }
+  - { "topic" : "Observability" }
+  20:
+  - { "topic" : "Randal Schwartz" }
+  21:
+  - { "module" : "Module::None" }
+  22:
+  - { "module" : "OpenMP" }
+  23:
+  - { "module" : "Perl::Version::Bumper" }
+  24:
+  - { "topic" : "Camel" }
+  25:
+  - { "topic" : "Merry Christmas, bless us, everyone" }


### PR DESCRIPTION
While looking for an article on the perladvent.org website from last year, I noticed that the archives only included up to and including 2023.  This change ensures that the articles from 2024 are now included in the [archives link](https://perladvent.org/archives.html) from the main advent calendar page.

I'm pretty sure I got the format right for the archives YAML config file, however, if I got anything wrong, please let me know and I'll be more than happy to update the PR as necessary.