### PR TITLE
Use cross-platform Perl command to get current year in example

### DIFF
--- a/script/assign-date.pl
+++ b/script/assign-date.pl
@@ -2,7 +2,7 @@
 
 =head1 SYNOPSIS
 
-    find 2024/incoming | fzf | xargs -I {} perl script/assign-date.pl --article {} --day 2
+    find $(perl -E 'say 1900+(localtime)[5]')/incoming | fzf | xargs -I {} perl script/assign-date.pl --article {} --day 2
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Replace hardcoded year with dynamic year lookup using Perl's localtime.
This works consistently on both macOS and Linux, unlike the date command
which has platform-specific syntax variations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
