### PR TITLE
Add syntax highlighting to code examples

### DIFF
--- a/2025/articles/2025-12-02.pod
+++ b/2025/articles/2025-12-02.pod
@@ -144,20 +144,22 @@ a background job that prepared images whenever new photos arrived in the
 
 She installed the module the usual way:
 
-    cpanm App::BlurFill
+  #!vim bash
+  cpanm App::BlurFill
 
 Then, in her image processing script, she added:
 
-    use App::BlurFill;
+  #!vim perl
+  use App::BlurFill;
 
-    my $blur_fill = App::BlurFill->new(
-      file   => 'images/santa-aurora.jpg',
-      width  => 1200,
-      height => 630,   # Nice “social card” size
-    );
+  my $blur_fill = App::BlurFill->new(
+    file   => 'images/santa-aurora.jpg',
+    width  => 1200,
+    height => 630,   # Nice "social card" size
+  );
 
-    my $output = $blur_fill->process;
-    print "Blurred image saved to $output\n";
+  my $output = $blur_fill->process;
+  print "Blurred image saved to $output\n";
 
 The constructor accepts:
 
@@ -223,7 +225,8 @@ Luckily, App::BlurFill ships with a command-line program, C<blurfill>.
 
 The syntax is:
 
-    blurfill [-w width] [-h height] [-o output_filename] image_filename
+  #!vim bash
+  blurfill [-w width] [-h height] [-o output_filename] image_filename
 
 If you omit the options, it uses the defaults:
 
@@ -246,11 +249,12 @@ elfies_blur.png
 
 So Pixie wrote a quick note on the internal wiki:
 
-    # Standard hero image (1200x630)
-    blurfill -w 1200 -h 630 aurora-santa.jpg
+  #!vim bash
+  # Standard hero image (1200x630)
+  blurfill -w 1200 -h 630 aurora-santa.jpg
 
-    # Story-style tall image (1080x1920)
-    blurfill -w 1080 -h 1920 reindeer-selfie.png
+  # Story-style tall image (1080x1920)
+  blurfill -w 1080 -h 1920 reindeer-selfie.png
 
 Within minutes, the marketing elves were gleefully pushing perfectly
 formatted images into their social media queues. They didn’t need to know how
@@ -267,11 +271,12 @@ plaintively. “Preferably without any of those scary flags?”
 Pixie was ready for this as well.
 
 The distribution includes a Dancer2 web interface, App::BlurFill::Web.
-There’s even a ready-made PSGI app in bin/app.psgi that just does:
+There's even a ready-made PSGI app in bin/app.psgi that just does:
 
-    use App::BlurFill::Web;
+  #!vim perl
+  use App::BlurFill::Web;
 
-    App::BlurFill::Web->to_app;
+  App::BlurFill::Web->to_app;
 
 Under the hood, that web app offers:
 
@@ -298,7 +303,8 @@ specify them.
 
 In a typical development environment, Pixie could run:
 
-    plackup bin/app.psgi
+  #!vim bash
+  plackup bin/app.psgi
 
 Suddenly any elf could:
 


### PR DESCRIPTION
Added vim syntax highlighting directives (#!vim bash, #!vim perl) to
all code blocks with 2-space indentation for proper rendering.

Code blocks updated:
- cpanm installation command (bash)
- Perl API usage examples (perl)
- CLI command syntax and examples (bash)
- Dancer2 PSGI app example (perl)
- plackup command (bash)
