### PR TITLE
Replace Markdown link with POD link

### DIFF
--- a/2025/articles/2025-12-02.pod
+++ b/2025/articles/2025-12-02.pod
@@ -129,7 +129,7 @@ A Dancer2 web app so you can do it all in the browser.
 
 =item *
 
-A [Docker container](https://hub.docker.com/r/davorg/app-blurfill) that bundles
+A L<Docker container|https://hub.docker.com/r/davorg/app-blurfill> that bundles
 the web app so any elf with Docker can run it.
 
 =back


### PR DESCRIPTION
... because the link isn't displayed correctly as a link in the generated HTML, which is because the file is POD (and not Markdown) and links use a different syntax in POD to what they use in Markdown.

I happened to spot this issue while reading the article and thought this might help :-)

I had difficulties getting the site up and running in a local environment, hence I'm *mostly* sure that the POD link syntax is correct here, and it's a small change, so hopefully it's easy to verify. If you need anything fixed up, please don't hesitate to let me know and I'll be glad to make any necessary changes and update as necessary.