### PR TITLE
Fix screenshot workflow for PRs from forked repositories

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -29,17 +29,8 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: 🐳 Build Docker image
-        uses: docker/bake-action@v6
-        with:
-          files: docker-compose.yml
-          load: true
-          set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+        run: docker compose build
 
       - name: 🔍 Detect changed articles
         id: detect


### PR DESCRIPTION
## Summary
- Fixes the screenshot workflow that was failing for PRs from forked repositories
- Replaces docker/bake-action with simple `docker compose build` command
- Ensures docker-compose.yml is available in the working directory

## Problem
PR #576 (the first PR from a fork after switching to `pull_request_target`) failed with:
```
no configuration file provided: not found
```

The root cause was that `docker/bake-action` was building images directly from the remote GitHub repository (the fork) instead of from the local checkout. This meant docker-compose.yml wasn't present in the working directory when subsequent docker compose commands ran.

## Solution
Changed from `docker/bake-action` to simple `docker compose build` which:
- Uses the local checkout with docker-compose.yml present
- Works consistently for both forked and non-forked PRs  
- Simplifies the build process
- Removes unnecessary complexity from the workflow

## Testing
- Tested locally with `docker compose build` - works correctly
- This change should allow PR #576's screenshot workflow to succeed

Co-Authored-By: Claude <noreply@anthropic.com>