### PR TITLE
Improve /review-article slash command

### DIFF
--- a/.claude/commands/review-article.md
+++ b/.claude/commands/review-article.md
@@ -111,6 +111,23 @@ For each accepted change:
 1. Use the Edit tool to apply the fix to the article file
 2. Confirm the change was applied successfully
 
+## Step 5a: Format Perl Code Blocks with perltidy
+
+After applying all approved changes, format inline Perl code blocks:
+
+1. Extract all `=begin perl` / `=end perl` code blocks from the article
+2. For each code block:
+   - Run the code through `perltidy` to ensure consistent formatting
+   - Use standard perltidy options (default settings)
+   - Replace the original code block with the tidied version
+3. Command to use:
+   ```bash
+   # Extract code, run through perltidy, update article
+   perltidy --standard-output --standard-error-output
+   ```
+4. Note: Only format code blocks, not inline code examples in regular paragraphs
+5. Show the user which code blocks were reformatted and ask for confirmation before applying
+
 ## Step 6: Summary and Next Steps
 
 After reviewing all issues:


### PR DESCRIPTION
## Summary

Enhances the `/review-article` slash command with better guidance for reviewing POD articles:

- **Markdown syntax detection**: Flags common Markdown patterns that should be converted to POD:
  - Backticks for inline code (`` `foo` `` → `C<foo>`)
  - Markdown links (`[text](url)` → `L<text|url>`)
  - Markdown headings (`##` → `=head2`)
  - Bold/italic (`**bold**`, `*italic*` → `B<bold>`, `I<italic>`)
  - Markdown code blocks (` ```perl ` → `=begin perl`)

- **Improved push workflow**: Better instructions for pushing to PR author's fork vs same repo

## Motivation

Authors sometimes accidentally use Markdown syntax when writing POD articles. This enhancement helps editors catch and fix these formatting issues during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)