### PR TITLE
Fix build workflow condition to use full repository name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository_owner == 'perladvent'
+    if: github.repository == 'perladvent/Perl-Advent'
     name: Build and deploy site
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Changes the job condition from `github.repository_owner == 'perladvent'` to `github.repository == 'perladvent/Perl-Advent'` for more explicit and reliable scheduled run detection

## Test plan

- [ ] Verify scheduled workflow runs trigger correctly at midnight UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)