### PR TITLE
Use RSS mode rendering in site builder

### DIFF
--- a/lib/Perl/Advent/RSSModePatch.pm
+++ b/lib/Perl/Advent/RSSModePatch.pm
@@ -1,0 +1,104 @@
+package Perl::Advent::RSSModePatch;
+
+use strict;
+use warnings;
+
+use Encode ();
+use Pod::Elemental;
+use Pod::Elemental::Transformer::Codebox;
+use Pod::Elemental::Transformer::List;
+use Pod::Elemental::Transformer::PPIHTML;
+use Pod::Elemental::Transformer::Pod5;
+use Pod::Elemental::Transformer::RSSMode;
+use Pod::Elemental::Transformer::SynMux;
+use Pod::Elemental::Transformer::VimHTML;
+use Pod::Simple::XHTML 3.13;
+use WWW::AdventCalendar::Article ();
+
+our $VERSION = '0.001';
+
+my $orig_body_html = WWW::AdventCalendar::Article->can('body_html');
+
+no warnings 'redefine';
+
+*WWW::AdventCalendar::Article::_body_renderable_pod_with_core_transforms = sub {
+    my ($self) = @_;
+
+    my $body = $self->body;
+    $body = Encode::encode('utf-8', $body);
+
+    $body = "\n=encoding utf-8\n\n$body" unless $body =~ /^=encoding/s;
+
+    my $document = Pod::Elemental->read_string($body);
+
+    Pod::Elemental::Transformer::Pod5->new->transform_node($document);
+    Pod::Elemental::Transformer::List->new->transform_node($document);
+
+    my $mux = Pod::Elemental::Transformer::SynMux->new({
+        transformers => [
+            Pod::Elemental::Transformer::Codebox->new,
+            Pod::Elemental::Transformer::PPIHTML->new,
+            Pod::Elemental::Transformer::VimHTML->new,
+        ],
+    });
+
+    $mux->transform_node($document);
+
+    return $document->as_pod_string;
+};
+
+*WWW::AdventCalendar::Article::_render_string_to_html = sub {
+    my ($self, $string) = @_;
+
+    my $parser = Pod::Simple::XHTML->new;
+    $parser->perldoc_url_prefix('https://metacpan.org/module/');
+    $parser->output_string(\my $html);
+    $parser->html_h_level(2);
+    $parser->html_header('');
+    $parser->html_footer('');
+
+    $parser->parse_string_document(Encode::encode('utf-8', $string));
+
+    $html = "<div class='pod'>$html</div>";
+
+    $html =~ s{
+      \s*(<pre>)\s*
+      (<table\sclass='code-listing'>.+?
+      \s*</table>)\s*(?:<!--\shack\s-->)?\s*(</pre>)\s*
+    }{my $str = $2; $str =~ s/\G^\s\s[^\$]*$//gm; $str}gesmx;
+
+    return $html;
+};
+
+*WWW::AdventCalendar::Article::_build_body_html = sub {
+    my ($self) = @_;
+
+    my $pod = Pod::Elemental->read_string($self->_body_renderable_pod_with_core_transforms);
+    Pod::Elemental::Transformer::RSSMode->new({ web_mode => 1 })->transform_node($pod);
+
+    return $self->_render_string_to_html($pod->as_pod_string);
+};
+
+*WWW::AdventCalendar::Article::body_html_for_rss = sub {
+    my ($self) = @_;
+
+    my $pod = Pod::Elemental->read_string($self->_body_renderable_pod_with_core_transforms);
+    Pod::Elemental::Transformer::RSSMode->new->transform_node($pod);
+
+    return $self->_render_string_to_html($pod->as_pod_string);
+};
+
+# Feed summaries call body_html from WWW::AdventCalendar::build; route those calls
+# to RSS rendering while keeping page rendering on the normal accessor path.
+*WWW::AdventCalendar::Article::body_html = sub {
+    my ($self, @rest) = @_;
+
+    my ($caller_pkg) = caller;
+    if ($caller_pkg && $caller_pkg eq 'WWW::AdventCalendar') {
+        return $self->body_html_for_rss;
+    }
+
+    return $orig_body_html->($self, @rest);
+};
+
+1;

--- a/lib/Pod/Elemental/Transformer/RSSMode.pm
+++ b/lib/Pod/Elemental/Transformer/RSSMode.pm
@@ -1,0 +1,64 @@
+package Pod::Elemental::Transformer::RSSMode;
+
+use Moose;
+with 'Pod::Elemental::Transformer';
+
+use namespace::autoclean;
+
+has web_mode => (
+    is      => 'ro',
+    default => 0,
+);
+
+has _to_be_removed_regex => (
+    is       => 'ro',
+    init_arg => undef,
+    lazy     => 1,
+    builder  => '_build_to_be_removed_regex',
+);
+
+sub _build_to_be_removed_regex {
+    my ($self) = @_;
+    return qr/\Arss_only/ if $self->web_mode;
+    return qr/\Aweb_only/;
+}
+
+sub transform_node {
+    my ($self, $node) = @_;
+
+    # Remove mode-specific =for directives that do not apply.
+    $self->_remove_nodes($node);
+
+    # Convert remaining mode directives into regular html directives.
+    $self->_rename_nodes($node);
+}
+
+sub _rename_nodes {
+    my ($self, $node) = @_;
+
+    for my $child (@{ $node->children }) {
+        next unless $child->can('command') && $child->command eq 'for';
+
+        my $content = $child->content;
+        $content =~ s/\Aweb_only/html/;
+        $content =~ s/\Arss_only/html/;
+        $child->content($content);
+    }
+}
+
+sub _remove_nodes {
+    my ($self, $node) = @_;
+
+    $node->children([
+        grep {
+            !(
+                $_->can('command')
+                && $_->command eq 'for'
+                && $_->content =~ $self->_to_be_removed_regex
+            )
+        } @{ $node->children }
+    ]);
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/script/build-site.sh
+++ b/script/build-site.sh
@@ -14,6 +14,13 @@
 pwd
 set -eu -o pipefail
 
+# Prefer repo-local patches during site builds.
+export PERL5LIB="$(pwd)/lib${PERL5LIB:+:$PERL5LIB}"
+patch_module="-MPerl::Advent::RSSModePatch"
+if [[ " ${PERL5OPT:-} " != *" ${patch_module} "* ]]; then
+    export PERL5OPT="${patch_module}${PERL5OPT:+ ${PERL5OPT}}"
+fi
+
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in

--- a/t/rss_mode_rendering.t
+++ b/t/rss_mode_rendering.t
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+use v5.26;
+use warnings;
+
+use lib 'lib';
+use lib 'inc/WWW-AdventCalendar/lib';
+use lib 'inc/Pod-Elemental-Transformer-SynHi/lib';
+
+use Perl::Advent::RSSModePatch;
+use Test::More;
+use WWW::AdventCalendar::Article;
+
+my $calendar_stub = bless { uri => 'https://example.test/' }, 'WWW::AdventCalendar';
+
+my $article = WWW::AdventCalendar::Article->new(
+    calendar => $calendar_stub,
+    date     => bless({}, 'DateTime'),
+    title    => 'RSS Mode test',
+    topic    => 'Testing',
+    author   => 'Tester <tester@example.test>',
+    body     => <<'POD',
+=for web_only <p>Visible only on web pages.</p>
+
+=for rss_only <p>Visible only in feed summaries.</p>
+
+=for html <p>Visible in both web and feed output.</p>
+
+Shared paragraph.
+POD
+);
+
+my $web_html = $article->body_html;
+my $rss_html = $article->body_html_for_rss;
+
+like $web_html, qr/Visible only on web pages\./, 'web_html keeps web_only content';
+unlike $web_html, qr/Visible only in feed summaries\./, 'web_html strips rss_only content';
+
+like $rss_html, qr/Visible only in feed summaries\./, 'body_html_for_rss keeps rss_only content';
+unlike $rss_html, qr/Visible only on web pages\./, 'body_html_for_rss strips web_only content';
+
+like $web_html, qr/Shared paragraph\./, 'web_html keeps shared content';
+like $rss_html, qr/Shared paragraph\./, 'body_html_for_rss keeps shared content';
+like $web_html, qr/Visible in both web and feed output\./, 'web_html keeps normal html blocks';
+like $rss_html, qr/Visible in both web and feed output\./, 'body_html_for_rss keeps normal html blocks';
+
+done_testing;


### PR DESCRIPTION
## What
Enable RSS-specific rendering mode during site builds so feed summaries can diverge from webpage-only content.

## Why
Mission focus was GitHub issue #211 (use unmerged RSS mode in the site builder). The current builder path renders feed summaries from the same body path as web pages, so `=for web_only` / `=for rss_only` intent is not respected.

## How
Added repo-local `Pod::Elemental::Transformer::RSSMode` plus a runtime patch module that extends `WWW::AdventCalendar::Article` with RSS-aware rendering and routes feed-context `body_html` calls to RSS output.
Wired `script/build-site.sh` to load the patch via `PERL5LIB` and `PERL5OPT`, keeping the change scoped to site builds without requiring submodule pointer updates.

## Testing
- `docker compose run --rm perl-advent prove -v t/rss_mode_rendering.t`
- `docker compose run --rm perl-advent prove -lr t`


---
### Quality Report

**Changes**: 4 files changed, 221 insertions(+)

**Code scan**: clean

**Tests**: skipped

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

*Generated by Kōan post-mission quality pipeline*