### PR TITLE
Fix screenshot year detection for article preview workflow

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -36,18 +36,26 @@ jobs:
         id: detect
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          YEAR=$(date +%Y)
-          echo "year=$YEAR" >> "$GITHUB_OUTPUT"
 
-          # Get list of changed POD files in YEAR/incoming or YEAR/articles
+          # Get list of changed POD files in YYYY/incoming or YYYY/articles
           # For pull_request_target, we compare against the base ref
-          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep -E "${YEAR}/(incoming|articles)/.*\.pod$" || true)
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep -E '^[0-9]{4}/(incoming|articles)/.*\.pod$' || true)
 
           if [ -z "$CHANGED_FILES" ]; then
             echo "No article files changed"
             echo "has_articles=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          YEARS=$(echo "$CHANGED_FILES" | cut -d/ -f1 | sort -u)
+          YEAR_COUNT=$(echo "$YEARS" | wc -l | tr -d ' ')
+          if [ "$YEAR_COUNT" -ne 1 ]; then
+            echo "Expected changed article files from exactly one year, got:"
+            echo "$YEARS"
+            exit 1
+          fi
+          YEAR=$(echo "$YEARS" | head -n1)
+          echo "year=$YEAR" >> "$GITHUB_OUTPUT"
 
           echo "Changed article files:"
           echo "$CHANGED_FILES"
@@ -70,7 +78,7 @@ jobs:
         run: |
           # For incoming articles, first copy them to articles/ with sequential dates
           if echo "${{ steps.detect.outputs.changed_files }}" | grep -q "incoming"; then
-            docker compose run --rm perl-advent bash -c "perl script/render-incoming.pl && bash script/build-site.sh --single-year $YEAR --today ${YEAR}-12-25"
+            docker compose run --rm perl-advent perl script/render-incoming.pl --year "$YEAR"
           else
             docker compose run --rm perl-advent bash script/build-site.sh --single-year "$YEAR" --today "${YEAR}-12-25"
           fi

--- a/script/render-incoming.pl
+++ b/script/render-incoming.pl
@@ -3,11 +3,15 @@
 use v5.26;
 
 use DateTime   ();
+use Getopt::Long qw( GetOptions );
 use Path::Tiny qw( path );
 use JSON::PP   qw( encode_json );
 
+my $opt_year;
+GetOptions( 'year=i' => \$opt_year );
+
 my $now  = DateTime->now;
-my $year = $now->year;
+my $year = $opt_year // $now->year;
 
 path("$year/articles")->mkpath;
 path("$year/share/static")->mkpath;
@@ -43,10 +47,16 @@ for my $file ( path( $year, 'incoming' )->children(qr/.*/) ) {
     $file->copy($dest);
 }
 
-my $cmd = "./script/build-site.sh --single-year $year --today $year-12-25";
-say "🚀 running $cmd";
-my $result = `$cmd`;
-say $result;
+my $skip_build = $ENV{PERL_ADVENT_RENDER_INCOMING_SKIP_BUILD};
+if ($skip_build) {
+    say "⏭️  skipping build because PERL_ADVENT_RENDER_INCOMING_SKIP_BUILD is set";
+}
+else {
+    my $cmd = "./script/build-site.sh --single-year $year --today $year-12-25";
+    say "🚀 running $cmd";
+    my $result = `$cmd`;
+    say $result;
+}
 
 # Write the mapping file for screenshot workflow
 if (@mappings) {

--- a/t/render_incoming.t
+++ b/t/render_incoming.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+
+use Cwd qw( getcwd );
+use File::Temp qw( tempdir );
+use FindBin qw( $Bin );
+use JSON::PP qw( decode_json );
+use Path::Tiny qw( path );
+use Test::More;
+
+my $script = path( $Bin, '..', 'script', 'render-incoming.pl' )->realpath;
+ok( -f $script, 'render-incoming script exists' );
+
+my $tmp = tempdir( CLEANUP => 1 );
+my $cwd = getcwd();
+chdir $tmp or die "Could not chdir to temp dir: $!";
+
+path( '2025', 'incoming' )->mkpath;
+path( '2025', 'incoming', 'first-post.pod' )->spew_utf8("=head1 hello\n");
+path( '2025', 'incoming', 'banner.png' )->spew_raw("image");
+
+my $cmd = "PERL_ADVENT_RENDER_INCOMING_SKIP_BUILD=1 $^X $script --year 2025";
+my $output = `$cmd 2>&1`;
+is( $? >> 8, 0, 'render-incoming runs successfully with --year' )
+    or diag $output;
+
+my @rendered = path( '2025', 'articles' )->children(qr/\.pod$/);
+is( scalar @rendered, 1, 'one incoming article was copied to articles/' );
+like( $rendered[0]->basename, qr/^2025-12-\d{2}\.pod$/, 'rendered filename uses requested year' );
+
+ok( path( '2025', 'share', 'static', 'banner.png' )->exists,
+    'non-pod incoming asset copied to share/static' );
+
+ok( path('incoming-mappings.json')->exists, 'mapping file was written' );
+my $mapping_data = decode_json( path('incoming-mappings.json')->slurp_utf8 );
+is( scalar @$mapping_data, 1, 'mapping contains one entry' );
+is( $mapping_data->[0]{incoming}, '2025/incoming/first-post.pod',
+    'mapping incoming path uses requested year' );
+like( $mapping_data->[0]{html}, qr/^2025-12-\d{2}\.html$/, 'mapping html filename uses requested year' );
+
+chdir $cwd or die "Could not chdir back to original directory: $!";
+
+done_testing;


### PR DESCRIPTION
## What
Make screenshot preview generation derive its target year from changed article paths instead of the runner clock.

## Why
Issue #408 screenshot previews currently assume `date +%Y`, which breaks when active article work is in a prior configured calendar year (for example, 2025 work reviewed in 2026).

## How
- Updated `.github/workflows/screenshot.yml` to detect changed POD files under `YYYY/(incoming|articles)` and compute the year from those paths.
- Added a single-year guard so the workflow fails fast on mixed-year article diffs instead of producing incorrect screenshots.
- Added `--year` support to `script/render-incoming.pl` and used it from the workflow for incoming article previews.
- Added `PERL_ADVENT_RENDER_INCOMING_SKIP_BUILD` for deterministic tests and new regression coverage in `t/render_incoming.t`.

## Testing
- `docker compose run --rm perl-advent perl -c script/render-incoming.pl`
- `docker compose run --rm perl-advent perl -MYAML::XS=LoadFile -e 'LoadFile(".github/workflows/screenshot.yml")'`
- `docker compose run --rm perl-advent prove -v t/render_incoming.t`
- `docker compose run --rm perl-advent prove -lr t`


---
### Quality Report

**Changes**: 3 files changed, 71 insertions(+), 10 deletions(-)

**Code scan**: clean

**Tests**: skipped

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

*Generated by Kōan post-mission quality pipeline*